### PR TITLE
Handle overlay directories that are populated by host-init scripts

### DIFF
--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -324,6 +324,13 @@ def makeImage(config):
         if 'base-img' in config:
             shutil.copy(config['base-img'], config['img'])
   
+    # Convert overlay to file list
+    if 'overlay' in config:
+        config.setdefault('files', [])
+        files = glob.glob(os.path.join(config['overlay'], '*'))
+        for f in files:
+            config['files'].append(FileSpec(src=f, dst='/'))
+
     if 'files' in config:
         log.info("Applying file list: " + str(config['files']))
         copyImgFiles(config['img'], config['files'], 'in')

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -182,13 +182,6 @@ class Config(collections.MutableMapping):
         if 'guest-init' in self.cfg:
             self.cfg['guest-init'] = RunSpec(script=self.cfg['guest-init'])
 
-        # Convert overlay to file list (main program doesn't handle overlays directly)
-        if 'overlay' in self.cfg:
-            self.cfg.setdefault('files', [])
-            files = glob.glob(os.path.join(self.cfg['overlay'], '*'))
-            for f in files:
-                self.cfg['files'].append(FileSpec(src=f, dst='/'))
-
         # Convert jobs to standalone configs
         if 'jobs' in self.cfg:
             jList = self.cfg['jobs']


### PR DESCRIPTION
Marshal used to inspect overlay directories at initialization time, before host-init had run. This could miss some derived files. This PR moves the overlay handling to after host-init has run.