### PR TITLE
Make 'command' scripts call 'sync; poweroff -f' to get around an issue

### DIFF
--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -185,7 +185,7 @@ def genRunScript(command):
     with open(commandScript, 'w') as s:
         s.write("#!/bin/bash\n")
         s.write(command + "\n")
-        s.write("poweroff\n")
+        s.write("sync; poweroff -f\n")
 
     return commandScript
 


### PR DESCRIPTION
There's an issue with buildroot not shutting down on FireSim (works in spike and qemu) when calling 'poweroff'. Until we sort it out, marshal will generate 'sync; poweroff -f' instead of 'poweroff'. This won't help with manual run scripts, only the 'command' option. 