### PR TITLE
Adds the sha3 example workload

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "boards/firechip/drivers/iceblk-driver"]
 	path = boards/firechip/drivers/iceblk-driver
 	url = https://github.com/firesim/iceblk-driver.git
+[submodule "workloads/sha3"]
+	path = workloads/sha3
+	url = https://github.com/ucb-bar/sha3-workload.git

--- a/workloads/sha3-bare-rocc.json
+++ b/workloads/sha3-bare-rocc.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-bare-rocc.json

--- a/workloads/sha3-bare-sw.json
+++ b/workloads/sha3-bare-sw.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-bare-sw.json

--- a/workloads/sha3-linux-jtr-crack.json
+++ b/workloads/sha3-linux-jtr-crack.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-linux-jtr-crack.json

--- a/workloads/sha3-linux-jtr-test.json
+++ b/workloads/sha3-linux-jtr-test.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-linux-jtr-test.json

--- a/workloads/sha3-linux-jtr.json
+++ b/workloads/sha3-linux-jtr.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-linux-jtr.json

--- a/workloads/sha3-linux-test.json
+++ b/workloads/sha3-linux-test.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-linux-test.json

--- a/workloads/sha3-linux.json
+++ b/workloads/sha3-linux.json
@@ -1,0 +1,1 @@
+sha3/marshal-configs/sha3-linux.json


### PR DESCRIPTION
This will become a standard example workload. Chipyard includes the RTL for this accelerator as well.