### PR TITLE
Only build one binary for nodisk

### DIFF
--- a/full_test.sh
+++ b/full_test.sh
@@ -94,6 +94,14 @@ if [ ${PIPESTATUS[0]} != 0 ]; then
   exit 1
 fi
 
+echo "Running inheritance test" | tee -a $LOGNAME
+./test/inherit/test.py >> $LOGNAME
+if [ ${PIPESTATUS[0]} != 0 ]; then
+  echo "Failure" | tee -a $LOGNAME
+  SUITE_PASS=false
+  exit 1
+fi
+
 echo -e "\n\nMarshal full test complete. Log at: $LOGNAME"
 if [ $SUITE_PASS = false ]; then
   echo "FAILURE: Some tests failed" | tee -a $LOGNAME

--- a/test/host-init/host-init.sh
+++ b/test/host-init/host-init.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 echo "Global : host-init" > runOutput
+

--- a/test/inherit-child.json
+++ b/test/inherit-child.json
@@ -1,0 +1,10 @@
+{
+  "name" : "inherit-child",
+  "workdir" : "inherit",
+  "base" : "inherit-parent.json",
+  "command" : "cat /root/runOutput",
+  "testing" : {
+    "refDir" : "refOutput/child",
+    "strip" : true
+  }
+}

--- a/test/inherit-parent.json
+++ b/test/inherit-parent.json
@@ -1,0 +1,12 @@
+{
+  "name" : "inherit-parent",
+  "workdir" : "inherit",
+  "base" : "br-base.json",
+  "files" : [["runOutput", "/root/"]],
+  "host-init" : "host-init.sh",
+  "command" : "cat /root/runOutput",
+  "testing" : {
+    "refDir" : "refOutput/parent",
+    "strip" : true
+  }
+}

--- a/test/inherit/.gitignore
+++ b/test/inherit/.gitignore
@@ -1,0 +1,1 @@
+runOutput

--- a/test/inherit/host-init.sh
+++ b/test/inherit/host-init.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Global : host-init" > runOutput

--- a/test/inherit/refOutput/child/inherit-child/uartlog
+++ b/test/inherit/refOutput/child/inherit-child/uartlog
@@ -1,0 +1,1 @@
+Global : host-init

--- a/test/inherit/refOutput/parent/inherit-parent/uartlog
+++ b/test/inherit/refOutput/parent/inherit-parent/uartlog
@@ -1,0 +1,1 @@
+Global : host-init

--- a/test/inherit/test.py
+++ b/test/inherit/test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import subprocess as sp
+import sys
+import os
+import pathlib as pth
+import re
+
+# Should be the directory containing the test
+testSrc = pth.Path(__file__).parent.resolve()
+testCfg = testSrc.parent / "inherit-child.json"
+
+print("testSrc:",testSrc)
+print("testCfg:",testCfg)
+# Should be the directory containing marshal
+managerPath = pth.Path(os.getcwd()) / "marshal"
+if not managerPath.exists():
+    managerPath = testSrc / "../../marshal"
+    if not managerPath.exists():
+        print("Can't find marshal, this script should be called either from firemarshal root or firesim-software/test/inherit/", file=sys.stderr)
+        sys.exit(1)
+
+# Safety first kids: Always clean before you test
+print("Cleaning the test:")
+if sp.call(str(managerPath) + " clean " + str(testCfg), shell=True) != 0:
+    print("Test Failure: clean command failed", file=sys.stderr)
+    sys.exit(1)
+
+print("Cleaning host-init")
+(testSrc / 'runOutput').unlink()
+
+print("Testing child workload:")
+if sp.call(str(managerPath) + " test " + str(testCfg), shell=True) != 0:
+    print("Clean Test Failure", file=sys.stderr)
+    sys.exit(1)
+
+print("Inherit Test Success", file=sys.stderr)
+sys.exit()

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -33,13 +33,31 @@ def checkLinuxUpToDate(config):
     #   makefiles make this not too bad (it adds a few seconds per image). This
     #   function is left here to make it easier if/when we get around to doing
     #   it right.
-    return False 
+    return False
 
+def handleHostInit(config):
+    log = logging.getLogger()
+    if 'host-init' in config:
+       log.info("Applying host-init: " + config['host-init'])
+       if not os.path.exists(config['host-init']):
+           raise ValueError("host-init script " + config['host-init'] + " not found.")
+
+       run([config['host-init']], cwd=config['workdir'])
+ 
 def addDep(loader, config):
+    """Adds 'config' to the doit dependency graph ('loader')"""
+
+    hostInit = []
+    if 'host-init' in config:
+        loader.addTask({
+            'name' : config['host-init'],
+            'actions' : [(handleHostInit, [config])],
+        })
+        hostInit = [config['host-init']]
 
     # Add a rule for the binary
     file_deps = []
-    task_deps = []
+    task_deps = [] + hostInit
     if 'linux-config' in config:
         file_deps.append(config['linux-config'])
     
@@ -58,7 +76,7 @@ def addDep(loader, config):
     # workload needs an init script
     if config['nodisk'] and 'bin' in config:
         file_deps = []
-        task_deps = []
+        task_deps = [] + hostInit
         if 'img' in config:
             file_deps = [config['img']]
             task_deps = [config['img']]
@@ -77,11 +95,11 @@ def addDep(loader, config):
 
     # Add a rule for the image (if any)
     file_deps = []
-    task_deps = []
+    task_deps = [] + hostInit
     if 'img' in config:
         if 'base-img' in config:
-            task_deps = [config['base-img']]
-            file_deps = [config['base-img']]
+            task_deps += [config['base-img']]
+            file_deps += [config['base-img']]
         if 'files' in config:
             for fSpec in config['files']:
                 # Add directories recursively
@@ -141,15 +159,6 @@ def buildDepGraph(cfgs):
 
     return loader
 
-def handleHostInit(config):
-    log = logging.getLogger()
-    if 'host-init' in config:
-       log.info("Applying host-init: " + config['host-init'])
-       if not os.path.exists(config['host-init']):
-           raise ValueError("host-init script " + config['host-init'] + " not found.")
-
-       run([config['host-init']], cwd=config['workdir'])
- 
 def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
     # This should only be built once (multiple builds will mess up doit)
     global taskLoader
@@ -158,7 +167,7 @@ def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
         
     config = cfgs[cfgName]
 
-    handleHostInit(config)
+    # handleHostInit(config)
     imgList = []
     binList = []
 

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -48,6 +48,8 @@ def addDep(loader, config):
     """Adds 'config' to the doit dependency graph ('loader')"""
 
     hostInit = []
+    # Host-init task always runs because we can't tell if its uptodate and we
+    # don't know its inputs/outputs.
     if 'host-init' in config:
         loader.addTask({
             'name' : config['host-init'],
@@ -61,6 +63,12 @@ def addDep(loader, config):
     if 'linux-config' in config:
         file_deps.append(config['linux-config'])
     
+    # A child binary could conceivably rely on the parent rootfs. This also
+    # implicitly depends on the parent's host-init script (whcih the img
+    # depends on).
+    if 'base-img' in config:
+        task_deps.append(config['base-img'])
+
     if 'bin' in config:
         loader.addTask({
                 'name' : config['bin'],

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -180,9 +180,10 @@ def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
     binList = []
 
     if buildBin and 'bin' in config:
-        binList = [config['bin']]
         if config['nodisk']:
             binList.append(config['bin'] + '-nodisk')
+        else:
+            binList.append([config['bin']])
    
     if 'img' in config and buildImg:
         imgList.append(config['img'])


### PR DESCRIPTION
When you build a workload in diskless mode you generally shouldn't need the normal disk-based binary, but Marshal will always build it right now. This fixes it so that the disk-based binary is only built in nodisk mode if you have a guest-init. It's still needed for workloads with a guest-init because those need to boot the disk-based system in order to construct the rootfs (which is then integrated into an initramfs).

Resolves #62 