### PR TITLE
Skip coldplug module load

### DIFF
--- a/wlutil/br/buildroot-overlay/etc/init.d/S10mdev
+++ b/wlutil/br/buildroot-overlay/etc/init.d/S10mdev
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Run the mdev daemon
+#
+
+DAEMON="mdev"
+PIDFILE="/var/run/$DAEMON.pid"
+
+
+start() {
+	printf 'Starting %s: ' "$DAEMON"
+	start-stop-daemon -S -b -m -p $PIDFILE -x /sbin/mdev -- -df
+	[ $? -eq 0 ] && echo "OK" || echo "ERROR"
+
+	# Skip recursive sysfs scan if /lib/modules does not exist
+	if [ -d /lib/modules ] ; then
+		# coldplug modules
+		find /sys/ -name modalias -print0 | \
+			xargs -0 sort -u | \
+			tr '\n' '\0' | \
+			xargs -0 modprobe -abq
+	fi
+}
+
+stop() {
+	printf 'Stopping %s: ' "$DAEMON"
+	start-stop-daemon -K -p $PIDFILE
+	[ $? -eq 0 ] && echo "OK" || echo "ERROR"
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+  start|stop|restart)
+	"$1"
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart}"
+	exit 1
+esac
+
+exit $?


### PR DESCRIPTION
This replaces the BusyBox `mdev` init script to omit the recursive sysfs scan, which takes a while in simulation and is unnecessary, since no modules are expected to be loaded after the initramfs.

```sh
find /sys/ -name modalias -print0 | \
	xargs -0 sort -u | \
	tr '\n' '\0' | \
	xargs -0 modprobe -abq
```