### PR TITLE
Add Linux timebase-frequency divisor hack

### DIFF
--- a/workloads/br-base/linux-config
+++ b/workloads/br-base/linux-config
@@ -14,6 +14,11 @@ CONFIG_RISCV_BASE_PMU=y
 CONFIG_RISCV_ISA_C=n
 
 #
+# Kernel features
+#
+CONFIG_RISCV_TIMEBASE_DIV=16
+
+#
 # Boot options
 #
 CONFIG_CMDLINE="console=hvc0 earlycon=sbi"


### PR DESCRIPTION
This creates the illusion that the `mtime` RTC is slower than the actual hardware frequency, which makes simulations on F1 feel more responsive.

This currently affects only "br-base" and descendants.  We should consider reverting the Kconfig change post-tutorial and investigate a cleaner solution in the long term.