### PR TITLE
Mount sudo check

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,8 @@ To run in qemu:
 To install into FireSim (assuming you cloned this as a submodule of firesim):
 
     ./marshal install workloads/br-base.json
+
+# Security Note
+Be advised that FireMarshal will run initialization scripts provided by
+workloads. These scripts will have all the permissions your user has, be sure
+to read all workloads carefully before building them.

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -3,6 +3,10 @@
 FireMarshal Commands
 =======================
 
+.. Note:: Marshal commands may execute scripts defined in the workload with
+  full user permissions. Users should excercise caution when building and running
+  untrusted workloads.
+
 Core Options
 --------------------
 The base ``marshal`` command provides a number of options that apply to most

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -215,7 +215,7 @@ def makeInitramfs(srcs, cpioDir, includeDevNodes=False):
     cpios = []
     for src in srcs:
         dst = cpioDir / (src.name + '.cpio')
-        run("find -print0 | cpio --owner root:root --null -ov --format=newc > " + str(dst), shell=True, cwd=src)
+        run(sudoCmd + " sh -c 'find -print0 | cpio --owner root:root --null -ov --format=newc' > " + str(dst), shell=True, cwd=src)
         cpios.append(dst)
 
     if includeDevNodes:

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -216,7 +216,7 @@ def makeInitramfs(srcs, cpioDir, includeDevNodes=False):
     cpios = []
     for src in srcs:
         dst = cpioDir / (src.name + '.cpio')
-        run(sudoCmd + " sh -c 'find -print0 | cpio --owner root:root --null -ov --format=newc' > " + str(dst), shell=True, cwd=src)
+        toCpio(src, dst)
         cpios.append(dst)
 
     if includeDevNodes:

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -201,7 +201,6 @@ def waitpid(pid):
                 break
         time.sleep(0.25)
 
-
 if sp.run(['/usr/bin/sudo', '-ln', 'true']).returncode == 0:
     # User has passwordless sudo available, use the mount command (much faster)
     sudoCmd = "/usr/bin/sudo"
@@ -230,6 +229,14 @@ else:
         # modifying the image for a period after unmount. This is the documented
         # best-practice (see man guestmount).
         waitpid(mntPid)
+
+def toCpio(src, dst):
+    log = logging.getLogger()
+    log.debug("Creating Cpio archive from " + str(src))
+    with open(dst, 'wb') as outCpio:
+        p = sp.run([sudoCmd, "sh", "-c", "find -print0 | cpio --owner root:root --null -ov --format=newc"],
+                stderr=sp.PIPE, stdout=outCpio, cwd=src)
+        log.debug(p.stderr.decode('utf-8'))
 
 # Apply the overlay directory "overlay" to the filesystem image "img"
 # Note that all paths must be absolute

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -207,11 +207,11 @@ if sp.run(['/usr/bin/sudo', '-ln', 'true']).returncode == 0:
     sudoCmd = "/usr/bin/sudo"
     @contextmanager
     def mountImg(imgPath, mntPath):
-        run("sudo mount -o loop " + imgPath + " " + mntPath, shell=True)
+        run([sudoCmd,"mount", "-o", "loop", imgPath, mntPath])
         try:
             yield mntPath
         finally:
-            run('sudo umount ' + mntPath, shell=True)
+            run([sudoCmd, 'umount', mntPath])
 else:
     # User doesn't have sudo (use guestmount, slow but reliable)
     sudoCmd = ""


### PR DESCRIPTION
Marshal should work on systems without sudo, but using guestmount to move files around (especially for large images and lots of mounts) is slow. This PR auto-detects if the user has passwordless sudo available, and uses 'sudo mount -o loop' whenever possible to speed up build times.

Testing:
- full_test.sh passed (module known bugs fixed in #70) with sudo
- disk and nodisk tested with guestmount for test/flist.sh without sudo