### PR TITLE
Update CHANGELOG for v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 This changelog follows the format defined here: https://keepachangelog.com/en/1.0.0/
 
+## [1.7.0] - 2019-10-12
+This release primarily updates several FireMarshal defaults to recent
+upstreamed versions, notably: Linux (v5.3), Fedora (20190126), and Buildroot (2019.08).
+
+Also, offical documentation has moved to: https://firemarshal.readthedocs.io/en/latest/
+
+### Added
+* PR #47 enables custom arguments to spike and qemu (see also PR #48 that adds an example RoCC accelerator workload that uses these arguments)
+* PR #61 includes an example sha3 workload (matches example RTL in chipyard)
+
+### Changed
+* PR #40 Enables alternative package manager mirrors in Fedora (if the default mirrors go down)
+* PR #41 Switches the default Fedora image from a nightly build to a stable release.
+* PR #44 Enables compressed riscv instructions (RVC) by default in Linux
+* PR #46 Updates the default linux kernel to (mostly) upstream v5.3 from the previous non-standard fork of Linux
+  * Introduces an initramfs by default in all builds that install drivers for iceblk and icenic
+  * Workloads now use Linux kernel configuration fragments instead of full linux configurations (enables easy bumping of kernel versions)
+* PR #50 updates buildroot to 2019.08 and switches to the github mirror
+* PR #51 Moves marshal documentation to this repository (from FireSim). Docs now hosted at https://firemarshal.readthedocs.io/en/latest/.
+
+### Fixed
+* PR #57 fixes a bug where host-init scripts may not run in parent workloads unless they were built explicitly
+
 ## [1.6.0] - 2019-06-25
 This release introduces a number of bug-fixes and support for standalone behavior (marshal can now be cloned by itself on a machine without sudo). It also synchronizes with firesim release 1.6.
 


### PR DESCRIPTION
For release 1.7.0. This should be the head for that (hopefully we can do a bump up the submodule chain for everyone to get their releasenotes synced).

FYI: There will be a similar PR for dev to keep master/dev in sync.