### PR TITLE
supress output for sudo privileges check

### DIFF
--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -201,7 +201,7 @@ def waitpid(pid):
                 break
         time.sleep(0.25)
 
-if sp.run(['/usr/bin/sudo', '-ln', 'true']).returncode == 0:
+if sp.run(['/usr/bin/sudo', '-ln', 'true'], stdout=sp.DEVNULL).returncode == 0:
     # User has passwordless sudo available, use the mount command (much faster)
     sudoCmd = "/usr/bin/sudo"
     @contextmanager


### PR DESCRIPTION
This snuck through pr #71. You see an annoying '/bin/true' everytime you run marshal from the sudo privileges check. This just suppresses the useless output.