### PR TITLE
Br deps

### DIFF
--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -153,6 +153,7 @@ def buildDepGraph(cfgs):
                     'name' : dCfg['img'],
                     'actions' : [(dCfg['builder'].buildBaseImage, [])],
                     'targets' : [dCfg['img']],
+                    'file_dep' : dCfg['builder'].fileDeps(),
                     'uptodate': [(dCfg['builder'].upToDate, [])]
                 })
 

--- a/wlutil/fedora/fedora.py
+++ b/wlutil/fedora/fedora.py
@@ -32,6 +32,9 @@ class Builder:
     def buildBaseImage(self):
         wlutil.run(['make', "rootfs.img"], cwd=fed_dir)
 
+    def fileDeps(self):
+        return []
+
     # Return True if the base image is up to date, or False if it needs to be
     # rebuilt.
     def upToDate(self):


### PR DESCRIPTION
This is another attempt at detecting if buildroot is up to date. See #21.

Hashing the rootfs doesn't work because each build changes the rootfs (probably a timestamp somewhere), so we have to manually try to track down all the dependencies.

The dependencies this pr tracks are:
* br/buildroot-overlay
* br/buildoot-config
* the toolchain (linux headers and gcc version)
* br/br.py

Notably absent is anything in br/buildroot/. I'm not sure how to reliably track what is/isn't up to date there. If you manually rebuild buildroot (e.g. 'cd br/buildroot && make'), marshal will notice and rebuild the children. I think in the rare cases that someone is modifying buildroot itself (rather than the config or overlays), they can just re-run make manually to pick up the changes.