### PR TITLE
Better test logging

### DIFF
--- a/marshal
+++ b/marshal
@@ -115,23 +115,26 @@ def main():
                     parser.print_help()
 
             try:
-                wlutil.launchWorkload(cfgPath, cfgs, args.job, args.spike)
+                outputPath = wlutil.launchWorkload(cfgPath, cfgs, args.job, args.spike)
             except Exception as e:
                 log.exception("Failed to launch workload:")
+            if outputPath is not None:
+                log.info("Workload outputs available at: " + outputPath)
 
         elif args.command == "test":
-            log.info("Running: " + cfgPath)
-            res = wlutil.testWorkload(cfgPath, cfgs, args.verbose, spike=args.spike, cmp_only=args.manual)
+            log.info("Testing: " + cfgPath)
+            res, resPath = wlutil.testWorkload(cfgPath, cfgs, args.verbose, spike=args.spike, cmp_only=args.manual)
             if res is wlutil.testResult.failure:
-                print("Test Failed")
+                log.info("Test Failed")
+                log.info("Output available at: " + resPath)
                 suitePass = False
                 failCount += 1
             elif res is wlutil.testResult.skip:
-                print("Test Skipped")
+                log.info("Test Skipped")
                 skipCount += 1
             else:
-                print("Test Passed")
-            log.info("")
+                log.info("Test Passed")
+                log.info("Output available at: " + resPath)
 
         elif args.command == 'clean':
             # with contextlib.suppress(FileNotFoundError):

--- a/wlutil/test.py
+++ b/wlutil/test.py
@@ -196,18 +196,19 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
 
     try:
         if cmp_only is None:
-            with stdout_redirected(cmdOut):
-                # Build workload
-                log.info("Building test workload")
-                runTimeout(buildWorkload, testCfg['buildTimeout'])(cfgName, cfgs)
+            # Build workload
+            log.info("Building test workload")
+            runTimeout(buildWorkload, testCfg['buildTimeout'])(cfgName, cfgs)
 
-                # Run every job (or just the workload itself if no jobs)
-                if 'jobs' in cfg:
-                    for jName in cfg['jobs'].keys():
-                        log.info("Running job " + jName)
+            # Run every job (or just the workload itself if no jobs)
+            if 'jobs' in cfg:
+                for jName in cfg['jobs'].keys():
+                    log.info("Running job " + jName)
+                    with stdout_redirected(cmdOut):
                         runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, job=jName, spike=spike)
-                else:
-                    log.info("Running workload")
+            else:
+                log.info("Running workload")
+                with stdout_redirected(cmdOut):
                     runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, spike=spike)
 
         log.info("Testing outputs")    

--- a/wlutil/test.py
+++ b/wlutil/test.py
@@ -71,37 +71,6 @@ def cmpOutput(testDir, refDir, strip=False):
 
     return None
 
-# adapted from https://stackoverflow.com/questions/4675728/redirect-stdout-to-a-file-in-python/22434262#22434262
-def fileno(file_or_fd):
-    fd = getattr(file_or_fd, 'fileno', lambda: file_or_fd)()
-    if not isinstance(fd, int):
-        raise ValueError("Expected a file (`.fileno()`) or a file descriptor")
-    return fd
-
-# adapted from https://stackoverflow.com/questions/4675728/redirect-stdout-to-a-file-in-python/22434262#22434262
-@contextmanager
-def stdout_redirected(to=os.devnull, stdout=None):
-    if stdout is None:
-       stdout = sys.stdout
-
-    stdout_fd = fileno(stdout)
-    # copy stdout_fd before it is overwritten
-    #NOTE: `copied` is inheritable on Windows when duplicating a standard stream
-    with os.fdopen(os.dup(stdout_fd), 'wb') as copied: 
-        stdout.flush()  # flush library buffers that dup2 knows nothing about
-        try:
-            os.dup2(fileno(to), stdout_fd)  # $ exec >&to
-        except ValueError:  # filename
-            with open(to, 'wb') as to_file:
-                os.dup2(to_file.fileno(), stdout_fd)  # $ exec > to
-        try:
-            yield stdout # allow code to be run with the redirected stdout
-        finally:
-            # restore stdout to its previous value
-            #NOTE: dup2 makes stdout_fd inheritable unconditionally
-            stdout.flush()
-            os.dup2(copied.fileno(), stdout_fd)  # $ exec >&copied
-
 def runTimeout(func, timeout):
     def wrap(*args, **kwargs):
         p = mp.Process(target=func, args=args, kwargs=kwargs)
@@ -167,19 +136,27 @@ def stripUartlog(config, outputPath):
 
 # Build and run a workload and compare results against the testing spec
 # ('testing' field in config)
-# Returns wluitl.test.testResult
+# Returns wlutil.test.testResult
 def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
-    log = logging.getLogger()
+    """Test the workload specified by cfgName.
+    cfgName: unique name of the workload in the cfgs
+    cfgs: initialized configuration (contains all possible workloads)
+    verbose: If true, the workload outputs will be displayed live, otherwise
+        they will be silently logged.
+    spike: Test using spike instead of the default qemu
+    cmp_only (path): Do not run the workload. Instead, simply compare the
+        golden output against the path in cmp_only. For example, cmp_only could
+        point to the output of a FireSim run. 
 
-    if verbose:
-        cmdOut = sys.stdout
-    else:
-        cmdOut = os.devnull
+    Returns (wlutil.test.testResult, output directory)
+    """
+
+    log = logging.getLogger()
 
     cfg = cfgs[cfgName]
     if 'testing' not in cfg:
         log.info("Test " + os.path.basename(cfgName) + " skipping: No 'testing' field in config")
-        return testResult.skip
+        return testResult.skip, None
 
     testCfg = cfg['testing']
         
@@ -204,12 +181,10 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
             if 'jobs' in cfg:
                 for jName in cfg['jobs'].keys():
                     log.info("Running job " + jName)
-                    with stdout_redirected(cmdOut):
-                        runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, job=jName, spike=spike)
+                    runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, job=jName, spike=spike, interactive=verbose)
             else:
                 log.info("Running workload")
-                with stdout_redirected(cmdOut):
-                    runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, spike=spike)
+                runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, spike=spike, interactive=verbose)
 
         log.info("Testing outputs")    
         if 'strip' in testCfg and testCfg['strip']:
@@ -220,8 +195,7 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
             suitePass = False
             log.info("Test " + os.path.basename(cfgName) + " failure: output does not match reference")
             log.info(textwrap.indent(diff, '\t'))
-            log.info("Output available in " + testPath)
-            return testResult.failure
+            return testResult.failure, testPath
 
     except TimeoutError as e:
         suitePass = False
@@ -232,8 +206,7 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
         else:
             log.error("Internal tester error: timeout from unrecognized function: " + e.args[0])
         
-        log.info("Output available in " + testPath)
-        return testResult.failure
+        return testResult.failure, testPath
 
     except ChildProcessError as e:
         suitePass = False
@@ -244,18 +217,15 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
         else:
             log.error("Internal tester error: exception in unknown function: " + e.args[0])
         
-        log.info("Output available in " + testPath)
-        return testResult.failure
+        return testResult.failure, testPath
 
     except Exception as e:
         suitePass = False
         log.info("Test " + os.path.basename(cfgName) + " failure: Exception encountered")
         traceback.print_exc()
-        log.info("Output available in " + testPath)
-        return testResult.failure
+        return testResult.failure, testPath
 
-    log.info("Success - output available in " + testPath)
-    return testResult.success
+    return testResult.success, testPath
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check the outupt of a workload against a reference output. The reference directory should match the layout of test directory including any jobs, uartlogs, or file outputs. Reference uartlogs can be a subset of the full output (this will check only that the reference uartlog content exists somewhere in the test uartlog).")

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -148,16 +148,6 @@ def initLogging(verbose):
 # The arguments are identical to those for subprocess.call()
 # level - The logging level to use
 # check - Throw an error on non-zero return status?
-# def run(*args, level=logging.DEBUG, check=True, **kwargs):
-#     log = logging.getLogger()
-#
-#     try:
-#         out = sp.check_output(*args, universal_newlines=True, stderr=sp.STDOUT, **kwargs)
-#         log.log(level, out)
-#     except sp.CalledProcessError as e:
-#         log.log(level, e.output)
-#         if check:
-#             raise
 def run(*args, level=logging.DEBUG, check=True, **kwargs):
     log = logging.getLogger()
 


### PR DESCRIPTION
This cleans up some logging in launch and test.

* 'test'
    * logs more output now, especially the intermediate output from the build stage that was hidden before.
    * It also eliminates some hacky stack overflow copypasta.
    * Users can now check on the live output of a test in non-verbose mode (was previously piped to /dev/null).
* 'launch' now manually splits the output into the uartlog and stdout instead of using a shell and tee which is a little cleaner and self-contained.

This PR started because a host-init script was failing in one of my tests, but the ./marshal test command was suppressing the error. 