### PR TITLE
Detect Changes in buildroot submodule

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,2 +1,3 @@
 psutil
 doit
+gitpython


### PR DESCRIPTION
Buildroot base image now gets rebuilt if the buildroot submodule commit hash changes, or if it has any uncommitted changes. A warning is issued if there are uncommitted changes to make it more clear what is happening.