### PR TITLE
Better submodule error

### DIFF
--- a/marshal
+++ b/marshal
@@ -115,7 +115,6 @@ def main():
                     j['nodisk'] = True
 
         if args.command == "build":
-            # try:
             if args.binOnly or args.imgOnly:
                 # It's fine if they pass -IB, it just builds both
                 ret = wlutil.buildWorkload(cfgName, cfgs, buildBin=args.binOnly, buildImg=args.imgOnly)

--- a/wlutil/br/br.py
+++ b/wlutil/br/br.py
@@ -5,6 +5,7 @@ import logging
 import string
 import pathlib
 import git
+import doit
 from .. import wlutil
 
 # Note: All argument paths are expected to be absolute paths
@@ -69,6 +70,7 @@ def buildConfig():
             cwd=(br_dir / 'buildroot'))
     
 def buildBuildRoot():
+    wlutil.checkSubmodule(br_dir / 'buildroot')
     buildConfig()
 
     # Buildroot complains about some common PERL configurations
@@ -89,7 +91,14 @@ class Builder:
 
     # Build a base image in the requested format and return an absolute path to that image
     def buildBaseImage(self):
-        buildBuildRoot()
+        """Ensures that the image file specified by baseConfig() exists and is up to date.
+
+        This is called as a doit task.
+        """
+        try:
+            buildBuildRoot()
+        except wlutil.SubmoduleError as e:
+            return doit.exceptions.TaskFailed(e)
 
     def fileDeps(self):
         # List all files that should be checked to determine if BR is uptodate

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -200,7 +200,6 @@ def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
 
     # The order isn't critical here, we should have defined the dependencies correctly in loader 
     return doit.doit_cmd.DoitMain(taskLoader).run(binList + imgList)
-    # return doit.doit_cmd.DoitMain(taskLoader).run(["info", "/data/repos/fm2/images/smoke0-bin"])
 
 def makeInitramfs(srcs, cpioDir, includeDevNodes=False):
     """Generate a cpio archive containing each of the sources and store it in cpioDir.

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -78,19 +78,30 @@ rootfsMargin = 256*(1024*1024)
 # Useful for defining lists of files (e.g. 'files' part of config)
 FileSpec = collections.namedtuple('FileSpec', [ 'src', 'dst' ])
 
+# List of marshal submodules (those enabled by init-submodules.sh)
+marshalSubmods = [
+        linux_dir,
+        pk_dir,
+        busybox_dir,
+        wlutil_dir / 'br' / 'buildroot'] + \
+        list(board_dir.glob("drivers/*"))
+        
 class SubmoduleError(Exception):
     """Error representing a nonexistent or uninitialized submodule"""
     def __init__(self, path):
-        self.message = "Dependency missing or not initialized " + \
-                str(path) + \
-                ". Do you need to initialize submodules?"
         self.path = path
 
     def __repr__(self):
-        return "Submodule Error: \n" + self.message
+        return 'Submodule Error: ' + self.__str__()
 
     def __str__(self):
-        return self.__repr__()
+        if self.path in marshalSubmods:
+            return 'Marshal submodule "' + str(self.path) + \
+                    '" not initialized. Please run "./init-submodules.sh."'
+        else:
+            return "Dependency missing or not initialized " + \
+                    str(self.path) + \
+                    ". Do you need to initialize a submodule?"
 
 class RootfsCapacityError(Exception):
     """Error representing that the workload's rootfs has run out of disk space."""


### PR DESCRIPTION
The error messages weren't super clear before. Now we explicitly check for marshal-managed submodules (as opposed to workload-specific ones) and give an appropriate error message. In particular, we tell users to run ./init-submodules.sh if they need to.