### PR TITLE
Remove sha3 example workload (it now lives in the sha3 generator repo)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "boards/firechip/drivers/iceblk-driver"]
 	path = boards/firechip/drivers/iceblk-driver
 	url = https://github.com/firesim/iceblk-driver.git
-[submodule "example-workloads/sha3"]
-	path = example-workloads/sha3
-	url = https://github.com/ucb-bar/sha3-workload.git

--- a/example-workloads/sha3-bare-rocc.json
+++ b/example-workloads/sha3-bare-rocc.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-bare-rocc.json

--- a/example-workloads/sha3-bare-sw.json
+++ b/example-workloads/sha3-bare-sw.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-bare-sw.json

--- a/example-workloads/sha3-linux-jtr-crack.json
+++ b/example-workloads/sha3-linux-jtr-crack.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-linux-jtr-crack.json

--- a/example-workloads/sha3-linux-jtr-test.json
+++ b/example-workloads/sha3-linux-jtr-test.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-linux-jtr-test.json

--- a/example-workloads/sha3-linux-jtr.json
+++ b/example-workloads/sha3-linux-jtr.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-linux-jtr.json

--- a/example-workloads/sha3-linux-test.json
+++ b/example-workloads/sha3-linux-test.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-linux-test.json

--- a/example-workloads/sha3-linux.json
+++ b/example-workloads/sha3-linux.json
@@ -1,1 +1,0 @@
-sha3/marshal-configs/sha3-linux.json


### PR DESCRIPTION
This removes the sha3 workload example from marshal. It is now going to live in the sha3 repo. See ucb-bar/sha3#17