### PR TITLE
Use RVC instructions in buildroot

### DIFF
--- a/boards/firechip/base-workloads/br-base/linux-config
+++ b/boards/firechip/base-workloads/br-base/linux-config
@@ -11,8 +11,6 @@ CONFIG_PERF_EVENTS=y
 #
 CONFIG_RISCV_BASE_PMU=y
 
-CONFIG_RISCV_ISA_C=n
-
 #
 # Boot options
 #


### PR DESCRIPTION
The `defconfig` has this set, but the `linux-config` for buildroot unsets it for some reason. 