### PR TITLE
Revert "Use RVC instructions in kernel"

### DIFF
--- a/boards/firechip/base-workloads/br-base/linux-config
+++ b/boards/firechip/base-workloads/br-base/linux-config
@@ -11,6 +11,8 @@ CONFIG_PERF_EVENTS=y
 #
 CONFIG_RISCV_BASE_PMU=y
 
+CONFIG_RISCV_ISA_C=n
+
 #
 # Boot options
 #


### PR DESCRIPTION
Enabling RVC on buildroot breaks at least BOOM and maybe also Rocket on some configs (not sure exactly yet). Either way, we're reverting the change until we sort out the RTL bugs.