### PR TITLE
Doit opts

### DIFF
--- a/docs/source/marshalConfig.rst
+++ b/docs/source/marshalConfig.rst
@@ -85,3 +85,34 @@ By default, FireMarshal shrinks the rootfs of each workload to contain only
 requirement with the :ref:`workload-rootfs-size` option). Increasing this can
 drastically increase host-machine disk requirements as every image generated
 will be larger.
+
+``doitOpts``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+FireMarshal uses a python library called `doit
+<https://pydoit.org/contents.html>`_ to track build dependencies and avoid
+unnecessary recompilation. You may pass additional options to this library as a
+dictionary here. To see a description of these options, consult the doit help
+output:
+
+   ``$ doit help run``
+
+``verbosity``
+"""""""""""""""""
+This is equivalent to the '-v' option when calling doit from the command line.
+Note that FireMarshal performs much of its own logging that supersedes this
+option. You should not typically change this unless you have a good reason.
+Briefly:
+
+   * 0 capture (do not print) stdout/stderr from task.
+   * 1 capture stdout only.
+   * 2 do not capture anything (print everything immediately).
+
+``dep_file``
+""""""""""""""""
+Doit requires a database to track dependencies and build artifacts. Without
+this database, it will conservatively rebuild all tasks. For most use-cases,
+you can leave this option as '' (the empty string) to default to a centralized
+database for all invocations of marshal. Since FireMarshal uses absolute paths
+to identify most tasks, this should be safe. However, you may use a different
+location for this database if needed by setting this option to a path (the path
+will be taken as relative to wherever the marshal command was invoked).

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -17,8 +17,7 @@ class doitLoader(doit.cmd_base.TaskLoader):
 
     def load_tasks(self, cmd, opt_values, pos_args):
         task_list = [doit.task.dict_to_task(w) for w in self.workloads]
-        config = {'verbosity': 2}
-        return task_list, config
+        return task_list, {}
 
 def buildBusybox():
     """Builds the local copy of busybox (needed by linux initramfs).
@@ -201,7 +200,8 @@ def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
                 imgList.append(jCfg['img'])
 
     # The order isn't critical here, we should have defined the dependencies correctly in loader 
-    return doit.doit_cmd.DoitMain(taskLoader).run([str(p) for p in binList + imgList])
+    doitHandle = doit.doit_cmd.DoitMain(taskLoader, extra_config={'run': getOpt('doitOpts')})
+    return doitHandle.run([str(p) for p in binList + imgList])
 
 def makeInitramfs(srcs, cpioDir, includeDevNodes=False):
     """Generate a cpio archive containing each of the sources and store it in cpioDir.

--- a/wlutil/default-config.yaml
+++ b/wlutil/default-config.yaml
@@ -22,3 +22,14 @@ jlevel : ''
 
 # Number of extra bytes to leave free by default in filesystem images
 rootfs-margin : '256MiB'
+
+# Options to pass to the doit library (for the 'run' command). Documentation is
+# sparse, but you can run 'doit help run' for a few options.
+doitOpts :
+  # see the verbosity section of '$doit help run' for details
+  verbosity : 2
+  # Where to store the build history database for marshal (path is relative to
+  # where the marshal command is invoked). This allows you to have multiple
+  # databases if needed. Otherwise, '' defaults to one database for every
+  # invocation of FireMarshal.
+  dep_file : ''

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -123,7 +123,8 @@ userOpts = [
         'log-dir',
         'res-dir',
         'jlevel',  # int or str from user, converted to '-jN' after loading
-        'rootfs-margin' # int or str from user, converted to int bytes after loading
+        'rootfs-margin', # int or str from user, converted to int bytes after loading
+        'doitOpts', # Dictionary of options to pass to doit (for the 'run' section)
         ]
 
 # These represent all available derived options (constants and those generated
@@ -274,6 +275,9 @@ class marshalCtx(collections.MutableMapping):
         self['jlevel'] = '-j' + str(self['jlevel'])
         self['driver-dirs'] = self['board-dir'].glob('drivers/*')
         self['buildroot-dir'] = self['wlutil-dir'] / 'br' / 'buildroot'
+
+        if self['doitOpts']['dep_file'] == '':
+            self['doitOpts']['dep_file'] = str(self['gen-dir'] / 'marshaldb')
 
     def setRunName(self, configPath, operation):
         """Helper function for formatting a  unique run name. You are free to


### PR DESCRIPTION
Add doit configuration options to marshal's config system. Most importantly, this changes the location of the doit.db file (it now defaults to wlutil/generated/marshaldb.*. Users can also override this option if they need (unlikely, but possible).

This resolves #104 