### PR TITLE
[install] fix install error when copying outputs

### DIFF
--- a/wlutil/install.py
+++ b/wlutil/install.py
@@ -69,7 +69,7 @@ def installWorkload(cfgName, cfgs):
             fsCfg["common_rootfs"] = dummyPath
 
         if 'outputs' in targetCfg:
-            fsCfg["common_outputs"] = targetCfg['outputs']
+            fsCfg["common_outputs"] = [ f.as_posix() for f in targetCfg['outputs'] ]
 
     with open(str(fsTargetDir / "README"), 'w') as readme:
         readme.write(readmeTxt)


### PR DESCRIPTION
I must have missed this when doing #112. This leads to a cannot JSON serialization error if not fixed.

You can reproduce this if you try to install the `test/outputs.json` workload to FireSim.