### PR TITLE
Update CentOS dependencies

### DIFF
--- a/centos-requirements.txt
+++ b/centos-requirements.txt
@@ -6,7 +6,7 @@ libguestfs-tools
 dtc
 makeinfo
 texinfo
-yac
+yacc
 bison
 flex
 expat

--- a/centos-requirements.txt
+++ b/centos-requirements.txt
@@ -14,3 +14,4 @@ expat-devel
 glib-devel
 gtk2-devel
 ctags
+bc


### PR DESCRIPTION
`bc` is required for Linux kernel builds (specifically for header file generation).