### PR TITLE
Expand quickstart to a broader 'tutorials' section and clean up a bunch

### DIFF
--- a/docs/source/Tutorials/custom.rst
+++ b/docs/source/Tutorials/custom.rst
@@ -1,0 +1,126 @@
+.. _tutorial-custom:
+
+Custom Workloads
+======================
+While FireMarshal provides some basic built-in workloads for getting started
+(described in :ref:`tutorial-quickstart`), the real power lies in its ability
+to define custom workloads.
+
+A custom workload takes the form of a workload configuration file, and a
+directory containing any files needed by the workload. Additionally, workloads
+can be based on a parent workload to avoid duplicate work. These files can
+be anywhere you like, but FireMarshal must be able to find the workload
+descriptions. The default search paths for FireMarshal are as follows (in
+order):
+
+    #. Built-in workloads (defined in ``boards/firechip/base-workloads``)
+    #. The directory specified by the ``--workdir`` command-line option
+    #. The current working directory
+
+We now walk through two examples of building a custom workload. For full
+documentation of every option, see :ref:`workload-config`.
+
+Fedora-Based
+-----------------------------
+``example-workloads/example-fed.json``
+
+In this example, we produce a 2-node workload that runs two benchmarks:
+quicksort and spam-filtering. This will require installing a number of packages
+on Fedora, as well as cross-compiling some code. The configuration is as
+follows:
+
+.. include:: ../../../example-workloads/example-fed.json
+  :code: json
+
+The ``name`` field is required and (by convention) should match the name of the
+configuration file. Next is the ``base`` (fedora-base.json). This option
+specifies an existing workload to base off of. FireMarshal will first build
+``fedora-base.json``, and use a copy of its rootfs for example-fed before
+applying the remaining options. Additionally, if fedora-base.json specifies any
+configuration options that we do not include, we will inherit those (e.g. we
+will use the ``linux-config`` option specified by fedora-base). Notice that we
+do not specify a workload source directory. FireMarshal will look in
+``example-workloads/example-fed/`` for any sources specified in the remaining options
+(you can change this behavior with the :ref:`config-workdir` configuration option).
+
+Next come a few options that specify common setup options used by all jobs in
+this workload. The ``overlay`` option specifies a filesystem overlay to copy
+into our rootfs. In this case, it includes the source code for our benchmarks
+(see ``example-workloads/example-fed/overlay``). Next is a ``host-init``
+option, this is a script that should be run on the host before building. In our
+case, it cross-compiles the quicksort benchmark (cross-compilation is much
+faster than natively compiling).
+
+.. include:: ../../../example-workloads/example-fed/host-init.sh
+  :code: bash
+
+Next is ``guest-init``, this script should run exactly once natively within our
+workload. For example-fed, this script installs a number of packages that are
+required by our benchmarks. Note that guest-init scripts are run during the
+build process; this can take a long time, especially with fedora. You will see
+linux boot messages and may even see a login prompt. There is no need to login
+or interact at all, the guest-init script will run in the background. Note that
+guest-init.sh ends with a ``poweroff`` command, all guest-init scripts should
+include this (leave it off to debug the build process).
+
+.. include:: ../../../example-workloads/example-fed/guest-init.sh
+  :code: bash
+
+Finally, we specify the two jobs that will run on each simulated node. Job
+descriptions have the same format and options as normal workloads. However,
+notice that the job descriptions are much shorter than the basic descriptions.
+Jobs implicitly inherit from the root configuration. In this case, both qsort
+and spamBench will have the overlay and host/guest-init scripts already set up
+for them. If needed, you could override these options with a different ``base``
+option in the job description. In our case, we need only provide a custom
+``run`` option to each workload. The run option specifies a script that should
+run natively in each job every time the job is launched. In our case, we run
+each benchmark, collecting some statistics along the way, and then shutdown.
+Finishing a run script with ``poweroff`` is a common pattern that allows
+workloads to run automatically (no need to log-in or interact at all).
+
+.. include:: ../../../example-workloads/example-fed/runQsort.sh
+  :code: bash
+
+We can now build and launch this workload:
+
+::
+
+  ./marshal build workloads/example-fed.json
+  ./marshal launch -j qsort workloads/example-fed.json
+  ./marshal launch -j spamBench workloads/example-fed.json
+
+You will see each job launch and can inspect the live input. The outputs and
+uart log will be saved in in the ``runOutputs`` directory with a name like
+``runOutputs/example-fed-launch-2020-01-23--01-33-41-X17CZDQ4P3DW1QRI``.
+
+Bare-Metal Workload
+-------------------------
+``test/bare.json``
+
+FireMarshal was primarily designed to support linux-based workloads. However,
+it provides basic support for bare-metal workloads. Take ``test/bare.json`` as
+an example:
+
+.. include:: ../../../test/bare.json
+  :code: json
+
+This workload creates a simple "Hello World" bare-metal workload. This workload
+simply inherits from the "bare" distro in its ``base`` option. This tells
+FireMarshal to not attempt to build any linux binaries or rootfs's for this
+workload. It then includes a simple host-init script that simply calls the
+makefile to build the bare-metal boot-binary. Finally, it hard-codes a path to
+the generated boot-binary. Note that we can still use all the standard
+FireMarshal commands with bare-metal workloads. In this case, we provide a
+testing specification that simply compares the serial port output against the
+known good output of "Hello World!".
+
+.. todo:: Add (or link to) more detailed examples of bare-metal and rocc workloads.
+
+Next Steps
+-------------------
+For more examples, you can look in the ``test/`` directory. The full set of
+workload configuration options is documented at :ref:`workload-config`. You can
+also customize much of the default behavior of FireMarshal through config files
+or environment variables (see :ref:`marshal-config`). Finally, the available
+commands and their options are documented in :ref:`firemarshal-commands`.

--- a/docs/source/Tutorials/index.rst
+++ b/docs/source/Tutorials/index.rst
@@ -1,0 +1,10 @@
+.. _tutorials:
+
+Tutorials
+=============================
+
+.. toctree::
+   :maxdepth: 1
+
+   quickstart
+   custom

--- a/docs/source/Tutorials/quickstart.rst
+++ b/docs/source/Tutorials/quickstart.rst
@@ -1,5 +1,7 @@
-Quick Start
---------------------------------------
+.. _tutorial-quickstart:
+
+Quick Start (Built-In Workloads)
+=========================================
 
 After a fresh clone of the FireMarshal repository, you may need to update
 submodules. You may skip this step if you only intend to build bare-metal
@@ -10,13 +12,21 @@ workloads:
   ./init-submodules.sh
 
 FireMarshal comes with a few basic workloads that you can build right out of
-the box (in ``workloads/``). In this example, we will build and test the
-buildroot-based linux distribution (called *br-base*). We begin by building the
-workload:
+the box. These builtin workloads include: br-base.json (buildroot) and fedora-base.json
+(fedora). You can see the source for these workloads at
+``boards/firechip/base-workloads``. In this example, we will build and test the
+buildroot-based linux distribution (called *br-base*). The instructions are
+identical for fedora, just replace br-base.json with fedora-base.json. We begin
+by building the workload:
 
 ::
 
-  ./marshal build workloads/br-base.json
+  ./marshal build br-base.json
+
+.. Note:: The ``base-workloads`` directory is on the default search path for
+   FireMarshal workloads. This means that we do not need to provide the full-path
+   to the br-base.json configuration file. For custom workloads, you will need to
+   provide a path to the workload configuration file. 
 
 The first time you build a workload may take a long time (buildroot must
 download and cross-compile a large number of packages), but subsequent builds
@@ -27,7 +37,7 @@ These are the boot-binary (linux + boot loader) and root filesystem
 
 ::
 
-  ./marshal launch workloads/br-base.json
+  ./marshal launch br-base.json
 
 You should now see linux booting and be presented with a login prompt. Sign in
 as 'root' with password 'firesim'. From here you can manipulate files, run
@@ -45,8 +55,8 @@ cleaned out any changes, let's clean and rebuild the workload:
 
 ::
 
-  ./marshal clean workloads/br-base.json
-  ./marshal build workloads/br-base.json
+  ./marshal clean br-base.json
+  ./marshal build br-base.json
 
 Note that this build took significantly less time than the first; FireMarshal
 caches intermediate build steps whenever possible.
@@ -59,8 +69,8 @@ you must first install it from FireMarshal:
 
 ::
 
-  ./marshal install workloads/br-base.json
+  ./marshal install br-base.json
 
 This command creates a firesim workload file at
 ``firesim/deploy/workloads/br-base.json``. You can now run this workload using
-the standard FireSim commands. 
+the standard FireSim commands.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,10 +25,10 @@ installed to a platform for running on real RTL (currently only FireSim is
 supported).
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
    :caption: Contents:
 
-   quickstart
+   Tutorials/index
    commands
    workloadConfig
    marshalConfig

--- a/docs/source/workloadConfig.rst
+++ b/docs/source/workloadConfig.rst
@@ -3,116 +3,21 @@
 Workload Specification
 =================================
 
-Workloads are defined by a configuration file and corresponding workload source
-directory, both typically in the ``workloads/`` directory. Most paths in the
+Workloads are defined by a JSON-formatted configuration file and corresponding workload source
+directory. These files can be anywhere on your filesystem. Most paths in the
 configuration file are assumed to be relative to the workload source directory.
 
-Example Configuration File
------------------------------
-FireMarshal supports many configuration options (detailed below), many of which
-are not commonly used. We will now walk through an example that uses most of
-the common options: ``workloads/example-fed.json``. In this example, we produce
-a 2-node workload that runs two benchmarks: quicksort and spam-filtering. This
-will require installing a number of packages on Fedora, as well as
-cross-compiling some code. The configuration is as follows:
-
-.. include:: ../../example-workloads/example-fed.json
-  :code: json
-
-The ``name`` field is required and (by convention) should match the name of the
-configuration file. Next is the ``base`` (fedora-base.json). This option
-specifies an existing workload to base off of. FireMarshal will first build
-``fedora-base.json``, and use a copy of its rootfs for example-fed before
-applying the remaining options. Additionally, if fedora-base.json specifies any
-configuration options that we do not include, we will inherit those (e.g. we
-will use the ``linux-config`` option specified by fedora-base). Notice that we
-do not specify a workload source directory. FireMarshal will look in
-``workloads/example-fed/`` for any sources specified in the remaining options.
-
-Next come a few options that specify common setup options used by all jobs in
-this workload. The ``overlay`` option specifies a filesystem overlay to copy
-into our rootfs. In this case, it includes the source code for our benchmarks
-(see ``workloads/example-fed/overlay``). Next is a ``host-init`` option, this
-is a script that should be run on the host before building. In our case, it
-cross-compiles the quicksort benchmark (cross-compilation is much faster than
-natively compiling).
-
-.. include:: ../../example-workloads/example-fed/host-init.sh
-  :code: bash
-
-Next is ``guest-init``, this script should run exactly once natively within our
-workload. For example-fed, this script installs a number of packages that are
-required by our benchmarks. Note that guest-init scripts are run during the
-build process; this can take a long time, especially with fedora. You will see
-linux boot messages and may even see a login prompt. There is no need to login
-or interact at all, the guest-init script will run in the background. Note that
-guest-init.sh ends with a ``poweroff`` command, all guest-init scripts should
-include this (leave it off to debug the build process).
-
-.. include:: ../../example-workloads/example-fed/guest-init.sh
-  :code: bash
-
-Finally, we specify the two jobs that will run on each simulated node. Job
-descriptions have the same format and options as normal workloads. However,
-notice that the job descriptions are much shorter than the basic descriptions.
-Jobs implicitly inherit from the root configuration. In this case, both qsort
-and spamBench will have the overlay and host/guest-init scripts already set up
-for them. If needed, you could override these options with a different ``base``
-option in the job description. In our case, we need only provide a custom
-``run`` option to each workload. The run option specifies a script that should
-run natively in each job every time the job is launched. In our case, we run
-each benchmark, collecting some statistics along the way, and then shutdown.
-Finishing a run script with ``poweroff`` is a common pattern that allows
-workloads to run automatically (no need to log-in or interact at all).
-
-.. include:: ../../example-workloads/example-fed/runQsort.sh
-  :code: bash
-
-We can now build and launch this workload:
-
-::
-
-  ./marshal build workloads/example-fed.json
-  ./marshal launch -j qsort workloads/example-fed.json
-  ./marshal launch -j spamBench workloads/example-fed.json
-
-For more examples, see the ``test/`` directory that contains many workloads
-used for testing FireMarshal.
-
-Bare-Metal Workloads
--------------------------
-FireMarshal was primarily designed to support linux-based workloads. However,
-it provides basic support for bare-metal workloads. Take ``test/bare.json`` as
-an example:
-
-.. include:: ../../test/bare.json
-  :code: json
-
-This workload creates a simple "Hello World" bare-metal workload. This workload
-simply inherits from the "bare" distro in its ``base`` option. This tells
-FireMarshal to not attempt to build any linux binaries or rootfs's for this
-workload. It then includes a simple host-init script that simply calls the
-makefile to build the bare-metal boot-binary. Finally, it hard-codes a path to
-the generated boot-binary. Note that we can still use all the standard
-FireMarshal commands with bare-metal workloads. In this case, we provide a
-testing specification that simply compares the serial port output against the
-known good output of "Hello World!".
-
-.. todo:: Add (or link to) more detailed examples of bare-metal and rocc workloads.
-
-Configuration File Options
-----------------------------
-Below is a complete list of configuration options available to FireMarshal.
+The available configuration options are:
 
 name
-^^^^^^^^^
+---------
 Name to use for the workload. Derived objects (rootfs/bootbin) will be named
 according to this option.
 
 *Non-heritable*
 
 base
-^^^^^^^^^^
+----------
 Configuration file to inherit from. FireMarshal will look in the same directory
 as the workload config file for the base configuration (or the workdir if
 ``--workdir`` was passed to the marshal command). A copy of the rootfs from ``base``
@@ -130,12 +35,12 @@ recommended way to generate bare-metal workloads.
 *Non-heritable*
 
 qemu
-^^^^^^^^^
+---------
 Path to binary to use for qemu (qemu-system-riscv64) when launching this
 workload. Defaults to the version of qemu-system-riscv64 on your $PATH.
 
 spike
-^^^^^^^^^^
+----------
 Path to binary for spike (riscv-isa-sim) to use when running this
 workload in spike. Useful for custom forks of spike to support custom
 instructions or hardware models. Defaults to the version of spike on your PATH.
@@ -143,13 +48,13 @@ instructions or hardware models. Defaults to the version of spike on your PATH.
 .. _workload-linux-src:
 
 linux-src
-^^^^^^^^^^^^^^^^
+----------------
 Path to riscv-linux source directory to use when building the boot-binary for
 this workload. Defaults to the riscv-linux source submoduled at
 ``riscv-linux/``.
 
 linux-config
-^^^^^^^^^^^^^^^^
+----------------
 Linux configuration fragment to use. This file has the same format as linux
 configuration files but only contains the options required by this workload.
 Marshal will include a few options on top of the RISC-V default configuration,
@@ -160,11 +65,11 @@ avoid specifying a custom initramfs since Marshal provides it's own for loading
 platform drivers.
 
 pk-src
-^^^^^^^^^^^^^^^
+---------------
 Path to riscv-pk source directory to use for this workload. This provides the bootloader (bbl). Defaults to the riscv-pk submodule included at ``riscv-pk/``.
 
 host-init
-^^^^^^^^^^^^^^
+--------------
 A script to run natively on your host (i.e., them machine where you
 invoked FireMarshal) from the workload source directory each time you
 explicitly build this workload. This option may include arguments for the script, e.g.
@@ -176,7 +81,7 @@ However, any affects that host-init has on the resulting rootfs *will* be
 reflected in the child.
 
 guest-init
-^^^^^^^^^^^^^^^
+---------------
 A script to run natively on the guest (in qemu) exactly once while building.
 The guest init script will be run from the root directory with root privileges.
 This script should end with a call to ``poweroff`` to make the build process
@@ -189,7 +94,7 @@ However, any affects that guest-init has on the resulting rootfs *will* be
 reflected in the child.
 
 post_run_hook
-^^^^^^^^^^^^^^^^^
+-----------------
 A script or command to run on the output of your run. At least the uart output of
 each run is captured, along with any file outputs specified in the `outputs`_
 option. This option may include arguments for the script, e.g.
@@ -216,7 +121,7 @@ When running as part of the ``test`` command, there will be a folder for each
 job in the workload.
 
 overlay
-^^^^^^^^^^^^
+------------
 Filesystem overlay to apply to the workload rootfs. An overlay should match the
 rootfs directory structure, with the overlay directory corresponding to the
 root directory. This is especially useful for overriding system configuration
@@ -224,7 +129,7 @@ files (e.g. /etc/fstab). The owner of all copied files will be changed to root
 in the workload rootfs after copying.
 
 files
-^^^^^^^^^^
+----------
 A list of files to copy into the rootfs. The file list has the following format:
 
 ::
@@ -236,7 +141,7 @@ paths are absolute with respect to the workload rootfs (e.g. ["file1",
 "/root/"]). The ownership of each file will be changed to 'root' after copying.
 
 outputs
-^^^^^^^^^^^^
+------------
 A list of files to copy out of the workload rootfs after running. Each path
 should be absolute with respect to the workload rootfs. Files will be placed
 together in the output directory. You cannot specify the directory structure of
@@ -245,7 +150,7 @@ the output.
 .. _workload-rootfs-size:
 
 rootfs-size
-^^^^^^^^^^^^^^^^^
+-----------------
 The desired rootfs size (in human-readable units, e.g. "4GB"). This number must
 either be >= to the parent workload's image size or set to 0. If set to 0, the
 rootfs will be shrunk to have only a modest amount of free space (the exact
@@ -257,7 +162,7 @@ margin is set by the :ref:`config-rootfs-size` global configuration option,
    The base workloads all have the default rootfs-margin included.
 
 run
-^^^^^^^^^^^^^
+-------------
 A script to run automatically every time this workload runs. The script will
 run after all other initialization finishes, but does not require the user to
 log in (run scripts run concurrently with any user interaction). Run scripts
@@ -273,28 +178,30 @@ e.g.  ``"run" : "foo.sh bar baz"``.
 *Non-heritable*
 
 command
-^^^^^^^^^^^^^
+-------------
 A command to run every time this workload runs. The command will be run from
 the root directory and will automatically call ``poweroff`` when complete (the
 user does not need to include this). 
 
 *Non-heritable*
 
+.. _config-workdir:
+
 workdir
-^^^^^^^^^^^
+-----------
 Directory to use as the workload source directory. Defaults to a directory with
 the same name as the configuration file.
 
 *Non-heritable*
 
 launch
-^^^^^^^^^^^
+-----------
 Enable/Disable launching of a job when running the 'test' command. This is
 occasionally needed for special 'dummy' workloads or other special-purpose jobs
 that only make sense when running on real RTL. Defaults to 'yes'.
 
 jobs
-^^^^^^^^^
+---------
 A list of configurations describing individual jobs that make up this workload.
 This list is ordered (on platforms that support ordering like FireSim, these jobs will be placed in-order in simulation slots).
 Job descriptions have the same syntax and options as normal workloads. The one
@@ -307,7 +214,7 @@ foo.img, foo-bar.img, and foo-baz.img.
 *Non-heritable*: You cannot use jobs as a ``base``, only base workloads.
 
 bin
-^^^^^^^^^
+---------
 Explicit path to the boot-binary to use. This will override any generated
 binaries created during the build process. This is particularly useful for
 bare-metal workloads that generate their own raw boot code.
@@ -315,14 +222,14 @@ bare-metal workloads that generate their own raw boot code.
 *Non-heritable*
 
 img
-^^^^^^^^^
+---------
 Explicit path to the rootfs to use. This will override any generated rootfs
 created during the build process.
 
 *Non-heritable*
 
 testing
-^^^^^^^^^^^^^
+-------------
 Provide details of how to test this workload. The ``test`` command will ignore
 any workload that does not have a ``testing`` field. This option is a map with
 the following options (only ``refDir`` is required):
@@ -330,7 +237,7 @@ the following options (only ``refDir`` is required):
 *Non-heritable*
 
 refDir
-""""""""""""""
+^^^^^^^^^^^^^^^
 Path to a directory containing reference outputs for this workload. Directory
 structures are compared directly (same folders, same file names). Regular files
 are compared exactly. Serial outputs (uartlog) need only match a subset of
@@ -338,7 +245,7 @@ outputs; the entire reference uartlog contents must exist somewhere
 (contiguously) in the test uartlog.
 
 buildTimeout
-""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^
 Maximum time (in seconds) that the workload should take to build. The test will
 fail if building takes longer than this. Defaults to infinite.
 
@@ -346,13 +253,13 @@ fail if building takes longer than this. Defaults to infinite.
   long time to build.
 
 runTimeout
-""""""""""""""""
+^^^^^^^^^^^^^^^^^^
 Maximum time (in seconds) that any particular job should take to run and exit.
 The test will fail if a job runs for longer than this before exiting. Defaults
 to infinite.
 
 strip
-"""""""""""""
+^^^^^^^^^^^^^^^^
 Attempt to clean up the uartlog output before comparing against the reference.
 This will remove all lines not generated by a run script or command, as well as
 stripping out any extra characters that might be added by the run-system (e.g.
@@ -360,26 +267,26 @@ the systemd timestamps on Fedora). This option is highly recommended on Fedora
 due to it's non-deterministic output.
 
 spike-args
-^^^^^^^^^^^^^^^
+---------------
 Provide additional commandline arguments to spike when launching or testing
 this workload. These may not override builtin options. Do not use this for
 setting cpu or memory sizes, see 'cpus' and 'mem' for how to change those
 options.
 
 qemu-args
-^^^^^^^^^^^^^^^
+---------------
 Provide additional commandline arguments to Qemu when launching or testing
 this workload. These may not override builtin options. Do not use this for
 setting cpu or memory sizes, see 'cpus' and 'mem' for how to change those
 options.
 
 cpus
-^^^^^^^^^^^^^
+-------------
 Set the number of cpus to use when launching or testing this workload in
 functional simulation. Does not affect the 'install' command.
 
 mem
-^^^^^^^^^^^^^
+-------------
 Set the amount of memory to use when launching or testing this workload in
 functional simulation. Does not affect the 'install' command. This value can be
 either a string with standard size annotations (e.g. "4GiB") or an integer


### PR DESCRIPTION
This cleans up a bunch of stuff in the quickstart/tutorial section of the docs. Especially since we're removing even more Marshal docs from firesim, I wanted to make sure everything was up to date.