### PR TITLE
Configurable firesim

### DIFF
--- a/marshal
+++ b/marshal
@@ -180,8 +180,11 @@ def main():
                         deleteSafe(jCfg['img'])
 
         elif args.command == 'install':
-            wlutil.installWorkload(cfgName, cfgs)
-
+            try:
+                wlutil.installWorkload(cfgName, cfgs)
+            except wlutil.ConfigurationError as e:
+                print(e)
+                sys.exit(1)
         else:
             log.error("No subcommand specified")
             sys.exit(1)

--- a/wlutil/default-config.yaml
+++ b/wlutil/default-config.yaml
@@ -16,6 +16,10 @@ log-dir : '../logs'
 # SW-simulation outputs
 res-dir : '../runOutput'
 
+# Location of the FireSim repository. Used by the 'install' command. Null
+# indicates that no FireSim installation is available.
+firesim-dir : null
+
 # Default parallelism level to use in subcommands (mostly when calling 'make')
 # '' means unbounded
 jlevel : ''

--- a/wlutil/install.py
+++ b/wlutil/install.py
@@ -15,15 +15,19 @@ def fullRel(base, target):
     return os.path.relpath(str(target), start=str(base))
 
 def installWorkload(cfgName, cfgs):
-    fsWork = ((getOpt('root-dir') / "../../deploy/workloads").resolve())
-    if fsWork == None:
-        raise RuntimeError("The install command is not supported when firesim-software is checked out standalone (i.e. not a submodule of firesim).")
+    fsDir = getOpt('firesim-dir')
+    if fsDir is None:
+        raise ConfigurationError("No firesim-dir option is set. Please configure the location of firesim in your config.yaml.")
+
+    fsWork = getOpt('firesim-dir') / "deploy/workloads"
+    if not fsWork.exists():
+        raise ConfigurationError("Configured firesim-dir (" + str(fsDir) + ") does not appear to be a valid firesim installation")
 
     targetCfg = cfgs[cfgName]
     # if 'jobs' in targetCfg:
     #     raise NotImplementedError("Jobs not currently supported by the install command")
     if targetCfg['nodisk'] == True:
-        raise NotImplementedError("Initramfs-based builds not currently supported by the install command")
+        raise NotImplementedError("nodisk builds not currently supported by the install command")
 
     fsTargetDir = fsWork / targetCfg['name']
     if not fsTargetDir.exists():

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -68,7 +68,7 @@ class ConfigurationError(Exception):
         self.cause = cause
 
     def __str__(self):
-        return "Configuration Error: " + cause
+        return "Configuration Error: " + self.cause
 
 class ConfigurationOptionError(ConfigurationError):
     """Error representing a problem with marshal configuration."""
@@ -99,13 +99,14 @@ def cleanPaths(opts, baseDir=pathlib.Path('.')):
         'board-dir',
         'image-dir',
         'linux-dir',
+        'firesim-dir',
         'pk-dir',
         'log-dir',
         'res-dir'
     ]
 
     for opt in pathOpts:
-        if opt in opts:
+        if opt in opts and opts[opt] is not None:
             try:
                 path = (baseDir / pathlib.Path(opts[opt])).resolve(strict=True)
                 opts[opt] = path
@@ -119,6 +120,7 @@ userOpts = [
         'board-dir',
         'image-dir',
         'linux-dir',
+        'firesim-dir',
         'pk-dir',
         'log-dir',
         'res-dir',


### PR DESCRIPTION
This adds the 'firesim-dir' option to firemarshal's configuration. This allow FireSim and Chipyard to explicitly tell FireMarshal where to find FireSim. This simplifies efforts to move FireMarshal into chipyard and is a prerequisite to those PRs (which are ready once this gets merged).