### PR TITLE
Support calling FireMarshal via make

### DIFF
--- a/full_test.sh
+++ b/full_test.sh
@@ -137,6 +137,17 @@ fi
 popd
 echo ""
 
+echo "Running recursive make test" | tee -a $LOGNAME
+pushd test/makefile
+make
+if [ ${PIPESTATUS[0]} != 0 ]; then
+  echo "Failure" | tee -a $LOGNAME
+  SUITE_PASS=false
+  exit 1
+fi
+popd
+echo ""
+
 echo -e "\n\nMarshal full test complete. Log at: $LOGNAME"
 if [ $SUITE_PASS = false ]; then
   echo "FAILURE: Some tests failed" | tee -a $LOGNAME

--- a/test/makefile.json
+++ b/test/makefile.json
@@ -1,0 +1,8 @@
+{
+  "name" : "makefile",
+  "base" : "br-base.json",
+  "command" : "echo Global: makefile",
+  "testing" : {
+      "refDir" : "refOutput"
+  }
+}

--- a/test/makefile/Makefile
+++ b/test/makefile/Makefile
@@ -1,0 +1,2 @@
+test:
+	cd ../ && ../marshal test makefile.json

--- a/test/makefile/refOutput/makefile/uartlog
+++ b/test/makefile/refOutput/makefile/uartlog
@@ -1,0 +1,1 @@
+Global: makefile

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -267,7 +267,7 @@ def makeDrivers(kfrags, boardDir, linuxSrc):
     # Prepare the linux source for building external drivers
     generateKConfig(kfrags, linuxSrc)
     run(["make", "ARCH=riscv", "CROSS_COMPILE=riscv64-unknown-linux-gnu-", "modules_prepare", getOpt('jlevel')], cwd=linuxSrc)
-    kernelVersion = sp.run(["make", "ARCH=riscv", "kernelrelease"], cwd=linuxSrc, stdout=sp.PIPE, universal_newlines=True).stdout.strip()
+    kernelVersion = sp.run(["make", "-s", "ARCH=riscv", "kernelrelease"], cwd=linuxSrc, stdout=sp.PIPE, universal_newlines=True).stdout.strip()
 
     drivers = []
     for driverDir in getOpt('driver-dirs'):


### PR DESCRIPTION
depmod would break when marshal was called via a Makefile. This is because recursive make has more output than normal make and we were using that to detect the kernel version for depmod. Marshal should now support recursive make.