### PR TITLE
Job drivers

### DIFF
--- a/test/drivers.json
+++ b/test/drivers.json
@@ -1,0 +1,9 @@
+{
+  "name" : "drivers",
+  "base" : "br-base.json",
+  "command" : "lsmod",
+  "testing" : {
+    "refDir" : "baseOutput",
+    "strip" : true
+  }
+}

--- a/test/drivers/baseOutput/drivers/uartlog
+++ b/test/drivers/baseOutput/drivers/uartlog
@@ -1,0 +1,3 @@
+Module                  Size  Used by    Tainted: G  
+iceblk                 45269  0 
+icenet                 80645  0 

--- a/test/drivers/jobOutput/driversJob-j0/uartlog
+++ b/test/drivers/jobOutput/driversJob-j0/uartlog
@@ -1,0 +1,3 @@
+Module                  Size  Used by    Tainted: G  
+iceblk                 45269  0 
+icenet                 80645  0 

--- a/test/driversJob.json
+++ b/test/driversJob.json
@@ -1,0 +1,15 @@
+{
+  "name" : "driversJob",
+  "base" : "br-base.json",
+  "workdir" : "drivers",
+  "command" : "lsmod",
+  "testing" : {
+    "refDir" : "jobOutput",
+    "strip" : true
+  },
+  "jobs" : [
+    {
+      "name" : "j0"
+    }
+  ]
+}

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -294,7 +294,7 @@ def makeDrivers(kfrags, boardDir, linuxSrc):
 
     # Always start from a clean slate
     try:
-        shutil.rmtree(driverDir)
+        shutil.rmtree(driverDir.parent)
     except FileNotFoundError:
         pass
     driverDir.mkdir(parents=True)
@@ -305,7 +305,6 @@ def makeDrivers(kfrags, boardDir, linuxSrc):
 
     # Setup the dependency file needed by modprobe to load the drivers
     run(['depmod', '-b', str(getOpt('initramfs-dir') / "drivers"), kernelVersion])
-
 
 def makeBin(config, nodisk=False):
     """Build the binary specified in 'config'.

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -275,7 +275,7 @@ class marshalCtx(collections.MutableMapping):
         self['run-name'] = ""
         self['rootfs-margin'] = humanfriendly.parse_size(str(self['rootfs-margin']))
         self['jlevel'] = '-j' + str(self['jlevel'])
-        self['driver-dirs'] = self['board-dir'].glob('drivers/*')
+        self['driver-dirs'] = list(self['board-dir'].glob('drivers/*'))
         self['buildroot-dir'] = self['wlutil-dir'] / 'br' / 'buildroot'
 
         if self['doitOpts']['dep_file'] == '':


### PR DESCRIPTION
Fix #130. The problem was that the 'driver-dirs' global option was a generator instead of a list, so if you read it more than once, the second read would not get anything.