### PR TITLE
Workload path

### DIFF
--- a/docs/source/Tutorials/custom.rst
+++ b/docs/source/Tutorials/custom.rst
@@ -10,12 +10,8 @@ A custom workload takes the form of a workload configuration file, and a
 directory containing any files needed by the workload. Additionally, workloads
 can be based on a parent workload to avoid duplicate work. These files can
 be anywhere you like, but FireMarshal must be able to find the workload
-descriptions. The default search paths for FireMarshal are as follows (in
-order):
-
-    #. Built-in workloads (defined in ``boards/firechip/base-workloads``)
-    #. The directory specified by the ``--workdir`` command-line option
-    #. The current working directory
+descriptions. See :ref:`workload-search-paths` for details on how FireMarshal
+searches for workloads.
 
 We now walk through two examples of building a custom workload. For full
 documentation of every option, see :ref:`workload-config`.
@@ -38,10 +34,7 @@ specifies an existing workload to base off of. FireMarshal will first build
 ``fedora-base.json``, and use a copy of its rootfs for example-fed before
 applying the remaining options. Additionally, if fedora-base.json specifies any
 configuration options that we do not include, we will inherit those (e.g. we
-will use the ``linux-config`` option specified by fedora-base). Notice that we
-do not specify a workload source directory. FireMarshal will look in
-``example-workloads/example-fed/`` for any sources specified in the remaining options
-(you can change this behavior with the :ref:`config-workdir` configuration option).
+will use the ``linux-config`` option specified by fedora-base).
 
 Next come a few options that specify common setup options used by all jobs in
 this workload. The ``overlay`` option specifies a filesystem overlay to copy

--- a/docs/source/Tutorials/quickstart.rst
+++ b/docs/source/Tutorials/quickstart.rst
@@ -25,8 +25,8 @@ by building the workload:
 
 .. Note:: The ``base-workloads`` directory is on the default search path for
    FireMarshal workloads. This means that we do not need to provide the full-path
-   to the br-base.json configuration file. For custom workloads, you will need to
-   provide a path to the workload configuration file. 
+   to the br-base.json configuration file. See :ref:`workload-search-paths` for
+   details on how workloads are located.
 
 The first time you build a workload may take a long time (buildroot must
 download and cross-compile a large number of packages), but subsequent builds
@@ -64,7 +64,7 @@ caches intermediate build steps whenever possible.
 Finally, FireMarshal supports installing workloads to the FireSim cycle-exact
 simulator. To do this, you will need to use the FireMarshal that comes with
 `FireSim <https://www.fires.im>`_ or `Chipyard
-<https://chipyard.readthedocs.io/en/latest/>`_. To run a workload in FireSim,
+<https://chipyard.readthedocs.io/en/latest/>`_ (or manually :ref:`configure firesim <config-firesim>`). To run a workload in FireSim,
 you must first install it from FireMarshal:
 
 ::

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -13,11 +13,14 @@ The base ``marshal`` command provides a number of options that apply to most
 sub-commands. You can also run ``marshal -h`` for the most up-to-date
 documentation.
 
+.. _command-opt-workdir:
+
 ``--workdir``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 By default, FireMarshal will search the same directory as the provided
 configuration file for ``base`` references and the workload source directory.
-This option instructs FireMarshal to look elsewhere for these references.
+This option instructs FireMarshal to look elsewhere for these references. See
+:ref:`workload-search-paths` for details of how workloads are located.
 
 ``-d --nodisk``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +91,7 @@ test
 --------------------------------------
 The test command will build and run the workload, and compare its output
 against the ``testing`` specification provided in its configuration. See
-:ref:`firemarshal-config` for details of the testing specification. If jobs
+:ref:`config-testing` for details of the testing specification. If jobs
 are specified, all jobs will be run independently and their outputs will be
 included in the output directory.
 
@@ -104,9 +107,10 @@ specification against a pre-existing output. This allows you to check the
 output of firesim runs against a workload. It is also useful when developing a
 workload test.
 
+.. _command-install:
+
 install
 --------------------------------------
-.. _firemarshal-install:
 
 Creates a firesim workload definition file in ``firesim/deploy/workloads`` with
 all appropriate links to the generated workload. This allows you to launch the

--- a/docs/source/internal/Build.rst
+++ b/docs/source/internal/Build.rst
@@ -70,14 +70,14 @@ archive by staging several filesystems at ``wlutil/initramfs{disk, nodisk,
 drivers}``:
 
 * ``disk/``: contains a fully-functioning root filesystem with a busybox-based
-environment and an init script that knows to load drivers and look for a disk
-to boot from (either ``/dev/vda`` for qemu or ``/dev/iceblk`` for firesim).
+  environment and an init script that knows to load drivers and look for a disk
+  to boot from (either ``/dev/vda`` for qemu or ``/dev/iceblk`` for firesim).
 * ``nodisk/``: contains just the init script to load drivers (it must be
-combined with a working root filesystem).
+  combined with a working root filesystem).
 * ``drivers/``: contains the platform drivers built earlier.
 * ``devNodes.cpio``: A pre-built archive containing the ``/dev/console`` and
-``/dev/tty`` special files. These require a special procedure to create so we
-only do it once and commit the result.
+  ``/dev/tty`` special files. These require a special procedure to create so we
+  only do it once and commit the result.
 
 Marshal combines the needed initramfs sources in a temporary directory into a
 single cpio archive and configures the kernel to include this archive at boot

--- a/docs/source/marshalConfig.rst
+++ b/docs/source/marshalConfig.rst
@@ -41,6 +41,15 @@ All path-like options are interpreted as relative to the location of the
 configuration file. Size options can be written in human readable form (e.g.
 '4KiB') or simply as the number of bytes (e.g. '4096').
 
+.. _config-workload-dirs:
+
+``workload-dirs``
+^^^^^^^^^^^^^^^^^^^^^
+List of paths to search when looking up workloads (either the target workload,
+or parent workloads). This list is ordered with later entries taking precedence
+of earlier entries. See :ref:`workload-search-paths` for details of how
+workloads are located.
+
 ``board-dir``
 ^^^^^^^^^^^^^^^^^
 Root for default board (platform-specific resources).
@@ -54,6 +63,12 @@ Location to store all outputs (binaries and images)
 Default linux source. This is intended to override the global default linux
 version, if you need a special kernel for your workload, you should set that in
 your workload configuration directly (see :ref:`workload-linux-src`).
+
+.. _config-firesim:
+
+``firesim-dir``
+^^^^^^^^^^^^^^^^^^^
+Location of the firesim repository to use for the :ref:`command-install` command.
 
 ``pk-dir``
 ^^^^^^^^^^^^^^^^^

--- a/docs/source/workloadConfig.rst
+++ b/docs/source/workloadConfig.rst
@@ -7,20 +7,44 @@ Workloads are defined by a JSON-formatted configuration file and corresponding w
 directory. These files can be anywhere on your filesystem. Most paths in the
 configuration file are assumed to be relative to the workload source directory.
 
-The available configuration options are:
+.. _workload-search-paths:
+
+Workload Search Paths
+-------------------------
+FireMarshal will search through several locations when attempting to find a
+reference workload (either as the target, or as a parent). In order (with later
+options taking precedence over earlier options):
+
+#. Default builtin workloads (defined by the board you are using). These
+   include things like ``br-base.json`` or ``fedora-base.json`` etc.
+#. The :ref:`config-workload-dirs` configuration option.
+#. The :ref:`command-opt-workdir` command line option.
+#. The parent directory of the target workload path provided on the command
+   line. In other words, treat the target as a relative path and look in the
+   same directory as the target for parent workloads.
+
+Workloads are identified uniquely by the name of the configuration file (e.g.
+`br-base.json`), not by their absolute paths. If a file with the same name is
+found later in the search order, it will be used instead of earlier
+occurrences. The :ref:`workload-name` must also be unique.
+
+Configuration Options
+-------------------------
+
+.. _workload-name:
 
 name
----------
+^^^^^^^^
 Name to use for the workload. Derived objects (rootfs/bootbin) will be named
 according to this option.
 
 *Non-heritable*
 
 base
-----------
+^^^^^^^^^^
 Configuration file to inherit from. FireMarshal will look in the same directory
 as the workload config file for the base configuration (or the workdir if
-``--workdir`` was passed to the marshal command). A copy of the rootfs from ``base``
+``^^workdir`` was passed to the marshal command). A copy of the rootfs from ``base``
 will be used when building this workload. Additionally, most configuration
 options will be inherited if not explicitly provided (options that cannot be
 inherited will be marked as 'non-heritable' in this documentation).
@@ -35,12 +59,12 @@ recommended way to generate bare-metal workloads.
 *Non-heritable*
 
 qemu
----------
+^^^^^^^^
 Path to binary to use for qemu (qemu-system-riscv64) when launching this
 workload. Defaults to the version of qemu-system-riscv64 on your $PATH.
 
 spike
-----------
+^^^^^^^^^^
 Path to binary for spike (riscv-isa-sim) to use when running this
 workload in spike. Useful for custom forks of spike to support custom
 instructions or hardware models. Defaults to the version of spike on your PATH.
@@ -48,13 +72,13 @@ instructions or hardware models. Defaults to the version of spike on your PATH.
 .. _workload-linux-src:
 
 linux-src
-----------------
+^^^^^^^^^^^^^^^^
 Path to riscv-linux source directory to use when building the boot-binary for
 this workload. Defaults to the riscv-linux source submoduled at
 ``riscv-linux/``.
 
 linux-config
-----------------
+^^^^^^^^^^^^^^^^
 Linux configuration fragment to use. This file has the same format as linux
 configuration files but only contains the options required by this workload.
 Marshal will include a few options on top of the RISC-V default configuration,
@@ -65,11 +89,11 @@ avoid specifying a custom initramfs since Marshal provides it's own for loading
 platform drivers.
 
 pk-src
----------------
+^^^^^^^^^^^^^^
 Path to riscv-pk source directory to use for this workload. This provides the bootloader (bbl). Defaults to the riscv-pk submodule included at ``riscv-pk/``.
 
 host-init
---------------
+^^^^^^^^^^^^^^
 A script to run natively on your host (i.e., them machine where you
 invoked FireMarshal) from the workload source directory each time you
 explicitly build this workload. This option may include arguments for the script, e.g.
@@ -81,7 +105,7 @@ However, any affects that host-init has on the resulting rootfs *will* be
 reflected in the child.
 
 guest-init
----------------
+^^^^^^^^^^^^^^
 A script to run natively on the guest (in qemu) exactly once while building.
 The guest init script will be run from the root directory with root privileges.
 This script should end with a call to ``poweroff`` to make the build process
@@ -94,7 +118,7 @@ However, any affects that guest-init has on the resulting rootfs *will* be
 reflected in the child.
 
 post_run_hook
------------------
+^^^^^^^^^^^^^^^^
 A script or command to run on the output of your run. At least the uart output of
 each run is captured, along with any file outputs specified in the `outputs`_
 option. This option may include arguments for the script, e.g.
@@ -121,7 +145,7 @@ When running as part of the ``test`` command, there will be a folder for each
 job in the workload.
 
 overlay
-------------
+^^^^^^^^^^^^
 Filesystem overlay to apply to the workload rootfs. An overlay should match the
 rootfs directory structure, with the overlay directory corresponding to the
 root directory. This is especially useful for overriding system configuration
@@ -129,7 +153,7 @@ files (e.g. /etc/fstab). The owner of all copied files will be changed to root
 in the workload rootfs after copying.
 
 files
-----------
+^^^^^^^^^^
 A list of files to copy into the rootfs. The file list has the following format:
 
 ::
@@ -141,7 +165,7 @@ paths are absolute with respect to the workload rootfs (e.g. ["file1",
 "/root/"]). The ownership of each file will be changed to 'root' after copying.
 
 outputs
-------------
+^^^^^^^^^^^^
 A list of files to copy out of the workload rootfs after running. Each path
 should be absolute with respect to the workload rootfs. Files will be placed
 together in the output directory. You cannot specify the directory structure of
@@ -150,7 +174,7 @@ the output.
 .. _workload-rootfs-size:
 
 rootfs-size
------------------
+^^^^^^^^^^^^^^^^
 The desired rootfs size (in human-readable units, e.g. "4GB"). This number must
 either be >= to the parent workload's image size or set to 0. If set to 0, the
 rootfs will be shrunk to have only a modest amount of free space (the exact
@@ -162,7 +186,7 @@ margin is set by the :ref:`config-rootfs-size` global configuration option,
    The base workloads all have the default rootfs-margin included.
 
 run
--------------
+^^^^^^^^^^^^
 A script to run automatically every time this workload runs. The script will
 run after all other initialization finishes, but does not require the user to
 log in (run scripts run concurrently with any user interaction). Run scripts
@@ -178,7 +202,7 @@ e.g.  ``"run" : "foo.sh bar baz"``.
 *Non-heritable*
 
 command
--------------
+^^^^^^^^^^^^
 A command to run every time this workload runs. The command will be run from
 the root directory and will automatically call ``poweroff`` when complete (the
 user does not need to include this). 
@@ -188,20 +212,20 @@ user does not need to include this).
 .. _config-workdir:
 
 workdir
------------
+^^^^^^^^^^
 Directory to use as the workload source directory. Defaults to a directory with
 the same name as the configuration file.
 
 *Non-heritable*
 
 launch
------------
+^^^^^^^^^^
 Enable/Disable launching of a job when running the 'test' command. This is
 occasionally needed for special 'dummy' workloads or other special-purpose jobs
 that only make sense when running on real RTL. Defaults to 'yes'.
 
 jobs
----------
+^^^^^^^^
 A list of configurations describing individual jobs that make up this workload.
 This list is ordered (on platforms that support ordering like FireSim, these jobs will be placed in-order in simulation slots).
 Job descriptions have the same syntax and options as normal workloads. The one
@@ -214,7 +238,7 @@ foo.img, foo-bar.img, and foo-baz.img.
 *Non-heritable*: You cannot use jobs as a ``base``, only base workloads.
 
 bin
----------
+^^^^^^^^
 Explicit path to the boot-binary to use. This will override any generated
 binaries created during the build process. This is particularly useful for
 bare-metal workloads that generate their own raw boot code.
@@ -222,14 +246,16 @@ bare-metal workloads that generate their own raw boot code.
 *Non-heritable*
 
 img
----------
+^^^^^^^^
 Explicit path to the rootfs to use. This will override any generated rootfs
 created during the build process.
 
 *Non-heritable*
 
+.. _config-testing:
+
 testing
--------------
+^^^^^^^^^^^^
 Provide details of how to test this workload. The ``test`` command will ignore
 any workload that does not have a ``testing`` field. This option is a map with
 the following options (only ``refDir`` is required):
@@ -267,26 +293,26 @@ the systemd timestamps on Fedora). This option is highly recommended on Fedora
 due to it's non-deterministic output.
 
 spike-args
----------------
+^^^^^^^^^^^^^^
 Provide additional commandline arguments to spike when launching or testing
 this workload. These may not override builtin options. Do not use this for
 setting cpu or memory sizes, see 'cpus' and 'mem' for how to change those
 options.
 
 qemu-args
----------------
+^^^^^^^^^^^^^^
 Provide additional commandline arguments to Qemu when launching or testing
 this workload. These may not override builtin options. Do not use this for
 setting cpu or memory sizes, see 'cpus' and 'mem' for how to change those
 options.
 
 cpus
--------------
+^^^^^^^^^^^^
 Set the number of cpus to use when launching or testing this workload in
 functional simulation. Does not affect the 'install' command.
 
 mem
--------------
+^^^^^^^^^^^^
 Set the amount of memory to use when launching or testing this workload in
 functional simulation. Does not affect the 'install' command. This value can be
 either a string with standard size annotations (e.g. "4GiB") or an integer

--- a/docs/source/workloadConfig.rst
+++ b/docs/source/workloadConfig.rst
@@ -44,7 +44,7 @@ base
 ^^^^^^^^^^
 Configuration file to inherit from. FireMarshal will look in the same directory
 as the workload config file for the base configuration (or the workdir if
-``^^workdir`` was passed to the marshal command). A copy of the rootfs from ``base``
+``--workdir`` was passed to the marshal command). A copy of the rootfs from ``base``
 will be used when building this workload. Additionally, most configuration
 options will be inherited if not explicitly provided (options that cannot be
 inherited will be marked as 'non-heritable' in this documentation).

--- a/full_test.sh
+++ b/full_test.sh
@@ -159,6 +159,17 @@ fi
 popd
 echo ""
 
+echo "Running workload-paths test" | tee -a $LOGNAME
+pushd test/workload-dirs/
+./test.sh | tee -a $LOGNAME
+if [ ${PIPESTATUS[0]} != 0 ]; then
+  echo "Failure" | tee -a $LOGNAME
+  SUITE_PASS=false
+  exit 1
+fi
+popd
+echo ""
+
 echo -e "\n\nMarshal full test complete. Log at: $LOGNAME"
 if [ $SUITE_PASS = false ]; then
   echo "FAILURE: Some tests failed" | tee -a $LOGNAME

--- a/marshal
+++ b/marshal
@@ -86,6 +86,10 @@ def main():
     # board builtin workloads (the *-base.json's).
     workdirs[wlutil.getOpt('workdir-builtin')] = None
 
+    # Configured search paths
+    for d in wlutil.getOpt('workload-dirs'):
+        workdirs[d] = None
+
     # User-provided workload search path
     if args.workdir is not None:
         workdirs[args.workdir] = None
@@ -113,7 +117,11 @@ def main():
             print("To check on progress, either call marshal with '-v' or see the live output at: ")
             print(wlutil.getOpt('log-dir') / (wlutil.getOpt('run-name') + ".log"))
 
-        targetCfg = cfgs[cfgName]
+        try:
+            targetCfg = cfgs[cfgName]
+        except KeyError as e:
+            log.error("Cannot locate workload: " + cfgName)
+            sys.exit(1)
    
         if args.initramfs or args.no_disk:
             targetCfg['nodisk'] = True

--- a/test/workload-dirs/test.sh
+++ b/test/workload-dirs/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+TESTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+pushd $TESTDIR
+
+marshal test command.json
+
+popd

--- a/wlutil/default-config.yaml
+++ b/wlutil/default-config.yaml
@@ -1,3 +1,7 @@
+# List of paths to search for parent workloads. See FireMarshal documentation
+# for details of how workload search paths are determined.
+workload-dirs: []
+
 # Root for default board (platform-specific stuff)
 board-dir : '../boards/firechip'
 

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -102,14 +102,25 @@ def cleanPaths(opts, baseDir=pathlib.Path('.')):
         'firesim-dir',
         'pk-dir',
         'log-dir',
-        'res-dir'
+        'res-dir',
+        'workload-dirs'
     ]
+
+    def clean(path):
+        return (baseDir / pathlib.Path(path)).resolve(strict=True)
 
     for opt in pathOpts:
         if opt in opts and opts[opt] is not None:
             try:
-                path = (baseDir / pathlib.Path(opts[opt])).resolve(strict=True)
-                opts[opt] = path
+                if isinstance(opts[opt], str):
+                    # Scalar path
+                    opts[opt] = clean(opts[opt])
+                else:
+                    # List of paths
+                    cleanedPaths = []
+                    for p in opts[opt]:
+                        cleanedPaths.append(clean(p))
+                    opts[opt] = cleanedPaths
             except Exception as e:
                 raise ConfigurationOptionError(opt, "Invalid path: " + str(e))
 
@@ -117,6 +128,7 @@ def cleanPaths(opts, baseDir=pathlib.Path('.')):
 # environment or config files). See default-config.yaml or the documentation
 # for the meaning of these options.
 userOpts = [
+        'workload-dirs',
         'board-dir',
         'image-dir',
         'linux-dir',


### PR DESCRIPTION
This adds the option to configure an arbitrary number of custom search paths for workloads. This allows you to define a set of base workloads for your project while keeping individual workloads elsewhere. It also documents the workload search procedure in more detail.

Also cleans up a few unrelated documentation errors that had been lurking.