### PR TITLE
Generated overlay

### DIFF
--- a/test/generateFiles.json
+++ b/test/generateFiles.json
@@ -1,0 +1,13 @@
+{
+  "name" : "generateFiles",
+  "base" : "br-base.json",
+  "host-init" : "generate.sh",
+  "overlay" : "overlay",
+  "command" : "cat /root/overlayInput && cat /root/fileInput && cat /root/generatedFileInput && cat /root/generatedOverlayInput",
+  "files" : [["fileInput", "/root/"], ["generatedFileInput", "/root/"]],
+  "post_run_hook" : "cleanup.sh",
+  "testing" : {
+    "refDir" : "refOutput",
+    "strip" : true
+  }
+}

--- a/test/generateFiles/.gitignore
+++ b/test/generateFiles/.gitignore
@@ -1,0 +1,2 @@
+generatedFileInput
+overlay/root/generatedOverlayInput

--- a/test/generateFiles/cleanup.sh
+++ b/test/generateFiles/cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+WORKDIR=$(dirname "${BASH_SOURCE[0]}")
+
+rm $WORKDIR/generatedFileInput
+rm $WORKDIR/overlay/root/generatedOverlayInput

--- a/test/generateFiles/fileInput
+++ b/test/generateFiles/fileInput
@@ -1,0 +1,1 @@
+fileInput

--- a/test/generateFiles/generate.sh
+++ b/test/generateFiles/generate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "generatedFile" > generatedFileInput
+echo "generatedOverlay" > overlay/root/generatedOverlayInput

--- a/test/generateFiles/overlay/root/overlayInput
+++ b/test/generateFiles/overlay/root/overlayInput
@@ -1,0 +1,1 @@
+overlayInput

--- a/test/generateFiles/refOutput/generateFiles/uartlog
+++ b/test/generateFiles/refOutput/generateFiles/uartlog
@@ -1,0 +1,4 @@
+overlayInput
+fileInput
+generatedFile
+generatedOverlay

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -66,7 +66,7 @@ def fileDepsTask(name, taskDeps=None, overlay=None, files=None):
     taskDeps should be a list of names of tasks that must run before
     calculating dependencies (e.g. host-init)"""
 
-    def overlayDeps(overlay, files):
+    def fileDeps(overlay, files):
         """The python-action for the filedeps task, returns a dictionary of dependencies"""
         deps = []
         if overlay is not None:
@@ -83,7 +83,7 @@ def fileDepsTask(name, taskDeps=None, overlay=None, files=None):
 
     task = {
             'name' : 'calc_' + name + '_dep',
-            'actions' : [ (overlayDeps, [overlay, files]) ],
+            'actions' : [ (fileDeps, [overlay, files]) ],
     }
     if taskDeps is not None:
         task['task_dep'] = taskDeps
@@ -179,20 +179,6 @@ def addDep(loader, config):
                 overlay=config.get('overlay'), files=config.get('files'))
             img_calc_deps.append(fdepsTask['name'])
             loader.addTask(fdepsTask)
-        # if 'files' in config:
-        #     for fSpec in config['files']:
-        #         # Add directories recursively
-        #         if fSpec.src.is_dir():
-        #             for root, dirs, files in os.walk(fSpec.src):
-        #                 for f in files:
-        #                     fdep = os.path.join(root, f)
-        #                     # Ignore symlinks
-        #                     if not os.path.islink(fdep):
-        #                         img_file_deps.append(fdep)
-        #         else:
-        #             # Ignore symlinks
-        #             if not os.path.islink(fSpec.src):
-        #                 img_file_deps.append(fSpec.src)
         if 'guest-init' in config:
             img_file_deps.append(config['guest-init'].path)
             img_task_deps.append(str(config['bin']))
@@ -446,6 +432,10 @@ def makeImage(config):
     # Resize if needed
     if config['img-sz'] != 0:
         resizeFS(config['img'], config['img-sz'])
+
+    if 'overlay' in config:
+        log.info("Applying Overlay: " + str(config['overlay']))
+        applyOverlay(config['img'], config['overlay'])
 
     if 'files' in config:
         log.info("Applying file list: " + str(config['files']))

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -58,6 +58,38 @@ def handlePostBin(config, linuxBin):
 
        run([config['post-bin'].path] + config['post-bin'].args, env=postbinEnv, cwd=config['workdir'])
 
+def fileDepsTask(name, taskDeps=None, overlay=None, files=None):
+    """Returns a task dict for a calc_dep task that calculates the file
+    dependencies representd by an overlay and/or a list of FileSpec objects.
+    Either can be None.
+    
+    taskDeps should be a list of names of tasks that must run before
+    calculating dependencies (e.g. host-init)"""
+
+    def overlayDeps(overlay, files):
+        """The python-action for the filedeps task, returns a dictionary of dependencies"""
+        deps = []
+        if overlay is not None:
+            deps.append(overlay)
+
+        if files is not None:
+            deps += [ f.src for f in files if not f.src.is_symlink() ]
+
+        for dep in deps.copy():
+            if dep.is_dir():
+                deps += [ child for child in dep.glob('**/*') ]
+
+        return { 'file_dep' : [ str(f) for f in deps if not f.is_dir() ] }
+
+    task = {
+            'name' : 'calc_' + name + '_dep',
+            'actions' : [ (overlayDeps, [overlay, files]) ],
+    }
+    if taskDeps is not None:
+        task['task_dep'] = taskDeps
+
+    return task
+
 def addDep(loader, config):
     """Adds 'config' to the doit dependency graph ('loader')"""
 
@@ -138,21 +170,29 @@ def addDep(loader, config):
     # Add a rule for the image (if any)
     img_file_deps = []
     img_task_deps = [] + hostInit + postBin + config['base-deps']
+    img_calc_deps = []
     if 'img' in config:
-        if 'files' in config:
-            for fSpec in config['files']:
-                # Add directories recursively
-                if fSpec.src.is_dir():
-                    for root, dirs, files in os.walk(fSpec.src):
-                        for f in files:
-                            fdep = os.path.join(root, f)
-                            # Ignore symlinks
-                            if not os.path.islink(fdep):
-                                img_file_deps.append(fdep)
-                else:
-                    # Ignore symlinks
-                    if not os.path.islink(fSpec.src):
-                        img_file_deps.append(fSpec.src)
+        if 'files' in config or 'overlay' in config:
+            # We delay calculation of files and overlay dependencies to runtime
+            # in order to catch any generated inputs
+            fdepsTask = fileDepsTask(config['name'], taskDeps=img_task_deps,
+                overlay=config.get('overlay'), files=config.get('files'))
+            img_calc_deps.append(fdepsTask['name'])
+            loader.addTask(fdepsTask)
+        # if 'files' in config:
+        #     for fSpec in config['files']:
+        #         # Add directories recursively
+        #         if fSpec.src.is_dir():
+        #             for root, dirs, files in os.walk(fSpec.src):
+        #                 for f in files:
+        #                     fdep = os.path.join(root, f)
+        #                     # Ignore symlinks
+        #                     if not os.path.islink(fdep):
+        #                         img_file_deps.append(fdep)
+        #         else:
+        #             # Ignore symlinks
+        #             if not os.path.islink(fSpec.src):
+        #                 img_file_deps.append(fSpec.src)
         if 'guest-init' in config:
             img_file_deps.append(config['guest-init'].path)
             img_task_deps.append(str(config['bin']))
@@ -166,7 +206,8 @@ def addDep(loader, config):
             'actions' : [(makeImage, [config])],
             'targets' : [config['img']],
             'file_dep' : img_file_deps,
-            'task_dep' : img_task_deps
+            'task_dep' : img_task_deps,
+            'calc_dep' : img_calc_deps
             })
 
 # Generate a task-graph loader for the doit "Run" command

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -247,13 +247,6 @@ class Config(collections.MutableMapping):
 
             self.cfg['files'] = fList
 
-        # Convert overlay to file list. Internal code can safely ignore the 'overlay' argument now.
-        if 'overlay' in self.cfg:
-            self.cfg.setdefault('files', [])
-            files = self.cfg['overlay'].glob('*')
-            for f in files:
-                self.cfg['files'].append(FileSpec(src=f, dst=pathlib.Path('/')))
-
         if 'outputs' in self.cfg:
             self.cfg['outputs'] = [ pathlib.Path(f) for f in self.cfg['outputs'] ]
 

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -497,16 +497,7 @@ def toCpio(src, dst):
                 stderr=sp.PIPE, stdout=outCpio, cwd=src)
         log.debug(p.stderr.decode('utf-8'))
 
-# Apply the overlay directory "overlay" to the filesystem image "img"
-# Note that all paths must be absolute
-def applyOverlay(img, overlay):
-    log = logging.getLogger()
-    flist = []
-    for f in overlay.glob('*'):
-        flist.append(FileSpec(src=f, dst=pathlib.Path('/')))
 
-    copyImgFiles(img, flist, 'in')
-    
 def resizeFS(img, newSize=0):
     """Resize the rootfs at img to newSize.
 
@@ -538,6 +529,7 @@ def resizeFS(img, newSize=0):
     run(['resize2fs', str(img)])
     return
 
+
 def copyImgFiles(img, files, direction):
     """Copies a list of type FileSpec ('files') to/from the destination image (img).
 
@@ -558,6 +550,17 @@ def copyImgFiles(img, files, direction):
                 run(sudoCmd + ['cp', '-a', src, str(f.dst)])
             else:
                 raise ValueError("direction option must be either 'in' or 'out'")
+
+
+def applyOverlay(img, overlay):
+    """Apply the overlay directory "overlay" to the filesystem image "img"
+       Note that all paths must be absolute"""
+    flist = []
+    for f in overlay.glob('*'):
+        flist.append(FileSpec(src=f, dst=pathlib.Path('/')))
+
+    copyImgFiles(img, flist, 'in')
+ 
 
 _toolVersions = None
 def getToolVersions():


### PR DESCRIPTION
Addresses #157 

File and Overlay handling used to happen at config load time which could miss generated inputs (e.g. from host-init). This checking has now been moved to runtime and ordered right before image creation (after anything might have been generated). It also cleans up some of the file handling in general.