### PR TITLE
Deferred submodule check

### DIFF
--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -64,7 +64,7 @@ def submoduleDepsTask(submodules, name=""):
     Packaging this in a calc_dep task avoids unnecessary checking that can be
     slow."""
     def submoduleDeps(submodules):
-        return { 'uptodate' : [ config_changed(checkGitStatus(sub), name=str(sub)+"_cfg_change") for sub in submodules ] }
+        return { 'uptodate' : [ config_changed(checkGitStatus(sub)) for sub in submodules ] }
 
     return  {
               'name' : name,
@@ -380,6 +380,7 @@ def makeDrivers(kfrags, boardDir, linuxSrc):
 
     # Setup the dependency file needed by modprobe to load the drivers
     run(['depmod', '-b', str(getOpt('initramfs-dir') / "drivers"), kernelVersion])
+
 
 def makeBin(config, nodisk=False):
     """Build the binary specified in 'config'.

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -58,6 +58,20 @@ def handlePostBin(config, linuxBin):
 
        run([config['post-bin'].path] + config['post-bin'].args, env=postbinEnv, cwd=config['workdir'])
 
+
+def submoduleDepsTask(submodules, name=""):
+    """Returns a calc_dep task for doit to check if submodule is up to date.
+    Packaging this in a calc_dep task avoids unnecessary checking that can be
+    slow."""
+    def submoduleDeps(submodules):
+        return { 'uptodate' : [ config_changed(checkGitStatus(sub), name=str(sub)+"_cfg_change") for sub in submodules ] }
+
+    return  {
+              'name' : name,
+              'actions' : [ (submoduleDeps, [ submodules ]) ]
+            }
+
+
 def addDep(loader, config):
     """Adds 'config' to the doit dependency graph ('loader')"""
 
@@ -87,14 +101,16 @@ def addDep(loader, config):
         else:
             targets = [str(config['bin'])]
 
+        bin_calc_dep_tsk = submoduleDepsTask([config.get('linux-src'), config.get('pk-src')], name="_submodule_deps_"+config['name'])
+        loader.addTask(bin_calc_dep_tsk)
+
         loader.addTask({
                 'name' : str(config['bin']),
                 'actions' : [(makeBin, [config])],
                 'targets' : targets,
                 'file_dep': bin_file_deps,
                 'task_dep' : bin_task_deps,
-                'uptodate' : [config_changed(checkGitStatus(config.get('linux-src'))),
-                    config_changed(checkGitStatus(config.get('pk-src')))]
+                'calc_dep' : [bin_calc_dep_tsk['name']]
                 })
         diskBin = [str(config['bin'])]
 

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -681,15 +681,7 @@ class config_changed(dict):
         self.config = config
         self.config_digest = None
         self.encoder = encoder
-
-        # The dict and name are required to make the config_changed object json
-        # serializable. Name must be set if the config_changed object is going
-        # to be added to the doit database (this happens when it's part of a
-        # calc_dep, but not when it's added to the task directly as an
-        # uptodate). If you don't, doit will not be able to determine if the
-        # graph has changed and will randomly rebuild or not.
         dict.__init__(self)
-        self.update({"name" : name})
 
     def _calc_digest(self):
         if isinstance(self.config, str):

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -677,7 +677,7 @@ class config_changed(dict):
     @var config (str) or (dict)
     @var encoder (json.JSONEncoder) Encoder used to convert non-default values.
     """
-    def __init__(self, config, encoder=None, name=""):
+    def __init__(self, config, encoder=None):
         self.config = config
         self.config_digest = None
         self.encoder = encoder


### PR DESCRIPTION
Dependent submodule git status checking is now deferred to runtime instead of being performed for every loaded config at launch time. This results in significant speedups for directories with many configs (like test/).

Partially resolves #149, but it doesn't fix the issue of unrelated workloads breaking everything if they can't be loaded (you can't have a partway-finished workload in a directory with good workloads).