### PR TITLE
Fix workload-dirs test

### DIFF
--- a/test/workload-dirs/.gitignore
+++ b/test/workload-dirs/.gitignore
@@ -1,0 +1,1 @@
+!marshal-config.yaml

--- a/test/workload-dirs/marshal-config.yaml
+++ b/test/workload-dirs/marshal-config.yaml
@@ -1,0 +1,1 @@
+workload-dirs: [../]


### PR DESCRIPTION
A critical file for the workload-dirs test was accidentally gitignored. Marshal itself was fine, just the test was broken. It passed on my machine for months because I hadn't done a fresh clone.