### PR TITLE
Disable Inherited Modules

### DIFF
--- a/docs/source/workloadConfig.rst
+++ b/docs/source/workloadConfig.rst
@@ -110,9 +110,11 @@ Kernel modules to compile and load automatically in your workload. Modules will
 be loaded in the initramfs before loading the main user root. Modules are
 identified by the .ko file name (the name listed by lsmod). Workload-defined
 modules with the same name as an inherited module will take precidence,
-allowing you to override system default drivers. If you need to manually load a
-module (it shouldn't be automatically loaded), you should manually compile it in a
-post-bin script instead.
+allowing you to override system default drivers. If the path is null, the
+module will not be included. This is useful for disabling inherited modules.
+
+If you need to manually load a module (it shouldn't be automatically loaded),
+you should manually compile it in a post-bin script instead.
 
 The specified module directory must contain a Makefile that can be invoked as:
 

--- a/scripts/fullTest.py
+++ b/scripts/fullTest.py
@@ -70,6 +70,7 @@ categoryTests = {
             'qemu',
             'run',
             'simArgs',
+            'noDrivers'
         ],
 
         # This tests both no-disk and spike. In theory, most (maybe all?) tests

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -404,6 +404,9 @@ def makeModules(cfg):
 
     linCfg = cfg['linux']
 
+    if len(linCfg['modules']) == 0:
+        return
+
     makeCmd = "make LINUXSRC=" + str(linCfg['source'])
 
     # Prepare the linux source for building external modules 

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -255,7 +255,11 @@ def initLinuxOpts(config):
         config['linux']['source'] = cleanPath(config['linux']['source'], config['workdir'])
 
     if 'modules' in config['linux']:
-        config['linux']['modules'] = { name : cleanPath(path, config['workdir']) for name, path in config['linux']['modules'].items() }
+        for name, path in config['linux']['modules'].items():
+            if path is None:
+               continue
+            else:
+                config['linux']['modules'][name] = cleanPath(path, config['workdir'])
 
 
 def inheritLinuxOpts(config, baseCfg):
@@ -277,6 +281,10 @@ def inheritLinuxOpts(config, baseCfg):
         for k, v in baseCfg['linux'].items():
             if k not in config['linux']:
                 config['linux'][k] = copy.copy(v)
+
+        for name, src in list(config['linux']['modules'].items()):
+            if src is None:
+                del config['linux']['modules'][name]
 
 
 def initFirmwareOpts(config):


### PR DESCRIPTION
modules can now have a null path to disable an inherited module. This is needed in order to disable default modules like device drivers.

draft, pending tests