### PR TITLE
Warn on Undefined Workload Opts

### DIFF
--- a/marshal
+++ b/marshal
@@ -23,6 +23,7 @@ def main():
     parser.add_argument('--workdir', help='Use a custom workload directory (defaults to the same directory as the first config file)', type=pathlib.Path)
     parser.add_argument('-v', '--verbose',
                         help='Print all output of subcommands to stdout as well as the logs', action='store_true')
+    parser.add_argument("--werr", action="store_true", help="Warnings will cause a fatal runtime error")
     parser.add_argument('-i', '--initramfs', action='store_true', help="Alias for --no-disk")
     parser.add_argument('-d', '--no-disk', action='store_true', help="Use the no-disk version of this workload (the rootfs will be included as an initramfs in the boot binary)")
     subparsers = parser.add_subparsers(title='Commands', dest='command')
@@ -75,7 +76,7 @@ def main():
 
     ctx = wlutil.getCtx()
 
-    wlutil.initLogging(args.verbose)
+    wlutil.initLogging(args.verbose, werr=args.werr)
 
     # Load all the configs from the workload directories
     # Order matters here, duplicate workload files found in later search paths
@@ -111,7 +112,7 @@ def main():
     for cfgPath in args.config_files:
         # Each config gets it's own logging output and results directory
         ctx.setRunName(cfgPath, args.command)
-        wlutil.initLogging(args.verbose)
+        wlutil.initLogging(args.verbose, werr=args.werr)
         cfgName = cfgPath.name
 
         log = logging.getLogger()

--- a/scripts/fullTest.py
+++ b/scripts/fullTest.py
@@ -107,7 +107,8 @@ categoryTests = {
                 'fsSize',
                 'makefile',
                 'testWorkdir',
-                'workload-dirs' 
+                'workload-dirs',
+                'undefinedOpt'
         ]
 }
 

--- a/test/undefinedOpt.json
+++ b/test/undefinedOpt.json
@@ -1,0 +1,9 @@
+{
+  "name" : "undefinedOpt",
+  "base" : "br-base.json",
+  "command" : "echo Global: undefinedOpt",
+  "InvalidOption!" : "Should fail with Werr",
+  "testing" : {
+      "refDir" : "refOutput"
+  }
+}

--- a/test/undefinedOpt/refOutput/undefinedOpt/uartlog
+++ b/test/undefinedOpt/refOutput/undefinedOpt/uartlog
@@ -1,0 +1,1 @@
+Global: undefinedOpt

--- a/test/undefinedOpt/test.py
+++ b/test/undefinedOpt/test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Call as ./test.py PATH/TO/MARSHAL"""
+
+import subprocess as sp
+import sys
+import os
+import pathlib as pth
+import re
+
+# Should be the directory containing the test
+testSrc = pth.Path(__file__).parent.resolve()
+testCfg = testSrc.parent / "undefinedOpt.json"
+
+if len(sys.argv) > 1:
+    managerPath = pth.Path(sys.argv[1])
+else:
+    # Should be the directory containing marshal
+    managerPath = pth.Path(os.getcwd()) / "marshal"
+    if not managerPath.exists:
+        managerPath = pth.Path(os.getcwd()) / "../../marshal"
+        if not managerPath.exists:
+            print("Can't find marshal, this script should be called either from firesim-software/ or firesim-software/test/incremental/", file=sys.stderr)
+            sys.exit(1)
+
+print("Cleaning the test the first time:")
+proc = sp.run([managerPath, "clean", str(testCfg)])
+if proc.returncode != 0:
+    print("Failure when cleaning test", file=sys.stderr)
+    sys.exit(1)
+
+print("Running with --werr, should fail:")
+proc = sp.run([managerPath, "--werr", "test", str(testCfg)])
+if proc.returncode == 0:
+    print("Test succeeded when it should have failed", file=sys.stderr)
+    sys.exit(1)
+
+print("Running without --werr should pass with a warning:")
+proc = sp.run([managerPath, "test", str(testCfg)], stdout=sp.PIPE)
+if proc.returncode != 0:
+    print("Test failed", file=sys.stderr)
+    sys.exit(1)
+elif "WARNING" not in proc.stdout.decode("utf-8"):
+    print("No warning present!")
+    sys.exit(1)
+
+print("Test Success", file=sys.stderr)
+sys.exit()

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -20,6 +20,8 @@ configUser = [
         'name',
         # Path to config to base off (or 'fedora'/'br' if deriving from a base config)
         'base',
+        # List of job configurations
+        'jobs',
         # Path to spike binary to use (use $PATH if this is omitted)
         'spike',
         # Optional extra arguments to spike
@@ -28,6 +30,8 @@ configUser = [
         'qemu',
         # Optional extra arguments to qemu
         'qemu-args',
+        # Hard-coded binary path
+        'bin',
         # Grouped linux options see the docs for subfields
         'linux',
         # Grouped firmware-related options
@@ -56,6 +60,8 @@ configUser = [
         'workdir',
         # (bool) Should we launch this config? Defaults to 'true'. Mostly used for jobs.
         'launch',
+        # Hard-coded path to image file
+        'img',
         # Size of root filesystem (human-readable string)
         'rootfs-size',
         # Number of CPU cores to simulate (applies only to functional simulation). Converted to int after loading.
@@ -63,8 +69,16 @@ configUser = [
         # Amount of memory (DRAM) to use when simulating (applies only to functional simulation).
         # Can be standard size-formatted string from user (e.g. '4G'), but
         # converted to bytes as int after loading.
-        'mem'
+        'mem',
+        # Testing-related options
+        'testing'
         ]
+
+# Config options only used internally by distro internal configs (defined in the distro python package itself)
+configDistro = [
+        'distro',
+        'builder'
+]
 
 # Deprecated options, will be translated to current equivalents early on in
 # loading. They can be ignored after that.
@@ -156,6 +170,18 @@ configFirmware = [
         "opensbi-build-args", # Additional arguments to make for openSBI. User provides string, cannonical form is list.
         ]
 
+# Members of the 'testing' option
+configTesting = [
+        # Directory containing reference outputs
+        'refDir',
+        # Timeout for building, test will fail after this time
+        'buildTimeout',
+        # Timeout for running the workload, test will fail after this time
+        'runTimeout',
+        # Strip as much non-deterministic and irrelevant output from the uartlog before comparing
+        'strip'
+]
+
 class RunSpec():
     def __init__(self, script=None, command=None, args=[]):
         """RunSpec represents a command or script to run in the target.
@@ -239,6 +265,33 @@ def translateDeprecated(config):
     for opt in configDeprecated:
         config.pop(opt, None)
 
+
+def verifyConfig(config):
+    """Check that the config passes basic sanity checks and doesn't contain any
+    undefined or obviously invalid options. More detailed checking is scattered
+    throughout the loading code, this is just for obvious easy-to-check stuff
+    on the raw config"""
+
+    log = logging.getLogger()
+
+    for k, v in config.items():
+        if k not in (configUser + configDeprecated + configDistro + ["cfg-file"]):
+            log.warning("Unrecognized Option: " + k)
+
+    if 'linux' in config:
+        for k, v in config['linux'].items():
+            if k not in configLinux:
+                log.warning("Unrecognized Option: " + k)
+
+    if 'firmware' in config:
+        for k, v in config['firmware'].items():
+            if k not in configFirmware:
+                log.warning("Unrecognized Option: " + k)
+
+    if 'testing' in config:
+        for k, v in config['testing'].items():
+            if k not in configTesting:
+                log.warning("Unrecognized Option: " + k)
 
 def initLinuxOpts(config):
     """Initialize the 'linux' option group of config"""
@@ -336,6 +389,7 @@ class Config(collections.MutableMapping):
         else:
             self.cfg = cfgDict
 
+        verifyConfig(self.cfg)
         translateDeprecated(self.cfg)
 
         cfgDir = None


### PR DESCRIPTION
see #176 

Currently, marshal will happily ignore unrecognized options in your workload configs. This is pretty annoying when you have a simple typo. This PR adds a warning.

To make things even more robust, I've also added a "--werr" option to marshal for extra careful runs if you want (hard failure on any warning).

fullTest.py passed