### PR TITLE
Sleep(1) before calling umount

### DIFF
--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -528,6 +528,7 @@ if sp.run(['/usr/bin/sudo', '-ln', 'true'], stdout=sp.DEVNULL).returncode == 0:
         try:
             yield mntPath
         finally:
+            time.sleep(1)
             run(sudoCmd + ['umount', mntPath])
 else:
     # User doesn't have sudo (use guestmount, slow but reliable)


### PR DESCRIPTION
Since updating my manager, i've repeatedly run into an apparent race where marshal tries to unmount the image while there's still lingering activity. I'm not sure if this is the "right" fix, but it's helped me. 