### PR TITLE
Bump fedora

### DIFF
--- a/boards/default/distros/fedora/Makefile
+++ b/boards/default/distros/fedora/Makefile
@@ -1,11 +1,11 @@
-RAWURL=http://fedora.riscv.rocks/kojifiles/work/tasks/944/320944/Fedora-Developer-Rawhide-20200108.n.0-sda.raw.xz
+RAWURL=https://dl.fedoraproject.org/pub/alt/risc-v/repo/virt-builder-images/images/Fedora-Minimal-Rawhide-20191123.n.1-sda.raw.xz
 COMPIMG=rootfs.img.xz
 NEWIMG=rootfs.img
 
 # Extract root partition without partition table
 # NOTE: Offset must be adjusted for different base image
 $(NEWIMG): $(COMPIMG)
-	xzcat -k $(COMPIMG) | dd of=$(NEWIMG) bs=512 skip=1007616
+	xzcat -k $(COMPIMG) | dd of=$(NEWIMG) bs=512 skip=1249280
 
 $(COMPIMG):
 	curl $(RAWURL) -o $(COMPIMG)

--- a/boards/firechip/base-workloads/fedora-base.json
+++ b/boards/firechip/base-workloads/fedora-base.json
@@ -1,5 +1,6 @@
 {
   "name" : "fedora-base",
+  "guest-init": "initRepos.sh",
   "distro" : {
       "name" : "fedora",
       "opts" : {}

--- a/boards/firechip/base-workloads/fedora-base/initRepos.sh
+++ b/boards/firechip/base-workloads/fedora-base/initRepos.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+dnf makecache
+poweroff


### PR DESCRIPTION
This bumps fedora to a more minimal image (and more recent build). We had previously been working off an arbitrary full-sized nightly from when they were first porting Fedora. This one seems a bit more stable and definitely much smaller (800MB vs 6GB). Despite the name, it's not all that minimal. For example, it includes Python.

I'm not sure if there are any packages we think should be included by default, but I can add a guest-init for that. I'm also considering adding a guest-init that updates the dnf repository caches to make installing stuff faster for everyone. Since the caches are old it takes a few minutes the first time you install something. Also, this is a good opportunity to update other stuff if we think there's something with Fedora we really need.

BTW: This is still experiencing ucb-bar/chipyard#950 but it boots in normal disk mode.