### PR TITLE
Add hook to run script after base image is created, but before the full image is made

### DIFF
--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -260,6 +260,9 @@ def addDep(loader, config):
         if 'guest-init' in config:
             img_file_deps.append(config['guest-init'].path)
             img_task_deps.append(str(config['bin']))
+        if 'host-init-post-img' in config:
+            img_file_deps.append(config['host-init-post-img'].path)
+            img_task_deps.append(str(config['bin']))
         if 'runSpec' in config and config['runSpec'].path != None:
             img_file_deps.append(config['runSpec'].path)
         if 'cfg-file' in config:
@@ -558,6 +561,13 @@ def makeImage(config):
     # Resize if needed
     if config['img-sz'] != 0:
         resizeFS(config['img'], config['img-sz'])
+
+    if 'host-init-post-img' in config:
+       log.info("Applying host-init-post-img: " + str(config['host-init-post-img']))
+       if not config['host-init-post-img'].path.exists():
+           raise ValueError("host-init-post-img script " + str(config['host-init-post-img']) + " not found.")
+
+       run([config['host-init-post-img'].path] + config['host-init-post-img'].args, cwd=config['workdir'])
 
     if 'overlay' in config:
         log.info("Applying Overlay: " + str(config['overlay']))

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -54,6 +54,7 @@ configUser = [
         'command',
         # Path to script to run on the guest exactly once when building
         'guest-init',
+        'host-init-post-img',
         # Path to directory for this workload, all user-provided paths will
         # be relative to this (but converted to absolute when loaded)
         'workdir',
@@ -458,7 +459,7 @@ class Config(collections.MutableMapping):
             self.cfg['runSpec'] = RunSpec(command=self.cfg['command'])
 
         # Handle script arguments
-        for sOpt in ['guest-init', 'post_run_hook', 'host-init', 'post-bin']:
+        for sOpt in ['guest-init', 'host-init-post-img', 'post_run_hook', 'host-init', 'post-bin']:
             if sOpt in self.cfg:
                 self.cfg[sOpt] = RunSpec.fromString(
                         self.cfg[sOpt],
@@ -538,7 +539,7 @@ class Config(collections.MutableMapping):
             self.cfg['use-parent-bin'] = True
             for opt in ['firmware', 'linux', 'host-init']:
                 if opt not in self.cfg:
-                    # Child doesn't overwrite a non-heritable option 
+                    # Child doesn't overwrite a non-heritable option
                     continue
                 elif self.cfg.get(opt, None) != baseCfg.get(opt, None):
                     self.cfg['use-parent-bin'] = False


### PR DESCRIPTION
Adding `host-init-post-img` will run a script similar to `host-init` but will run it once the initial image is made (aka the distro folder is configured / built).

Use case:
You are using buildroot and want to cross-compile some program Y. However, Y needs access to libraries that were cross-compiled in the buildroot image. You can use this to run a script after this point (when everything in buildroot is cross-compiled) and get access to its `output` `staging` area.

TODO:

- [ ] Figure out how to pass env. variables pointing to the distro directory. Double-check this works with Fedora as well (aka generalize it).
- [ ] Better naming of the flag
- [ ] Update the documents. Also probably elaborate on when `host-init`, `guest-init`, `post-bin` are run exactly.