### PR TITLE
Deprecate the use of a 'dev' branch

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ name: Lint Code Base
 #############################
 on:
   pull_request:
-    branches: [master, dev]
+    branches: [master]
 
 ###############
 # Set the Job #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,10 @@ Contributing to FireMarshal
 ## Contributing Changes
 We welcome contributions to FireMarshal through [github
 PRs](https://github.com/firesim/FireMarshal/pulls). **All PRs should be against
-the dev branch**. Master is only updated by the FireMarshal maintainers and
-serves as the stable release branch.
+the master branch**.
 
 Before submitting a PR:
-* Merge origin/dev to ensure you have the latest changes.
+* Merge origin/master to ensure you have the latest changes.
 * Run ./fullTest.py to ensure the basic unit-tests still work
 * Ensure all code passes lint (this will be enforced by github). You can
   manually check each file (or a glob) with the following command:
@@ -20,7 +19,6 @@ Before submitting a PR:
 * For bugs and feature requests: use the github issue tracker: https://github.com/firesim/FireMarshal/issues
 
 ## Branch management:
-1) **master**: Stable release. Updated by FireMarshal maintainers as part of a release. 
-2) **dev**: Unstable development. Dev should (hopefully) work at all times, but
-   there are no guarantees. All changes should be PRd against dev. 
-3) **All other branches**: Private development branches, typically not suitable for use.
+1) **tagged releases**: All stable releases are tagged and tracked with githubs releases mechanism.
+1) **master**: Unstable development. Master should work at all times, but there are no guarantees that bugs haven't been introduced.
+2) **All other branches**: Private development branches, typically not suitable for use.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,13 @@ Be advised that FireMarshal will run initialization scripts provided by
 workloads. These scripts will have all the permissions your user has, be sure
 to read all workloads carefully before building them.
 
+# Releases
+The master branch of this project contains the latest unstable version of
+FireMarshal. It should generally work correctly, but it may contain bugs or
+other inconsistencies from time to time. For stable releases, see the release
+git tags or github releases page.
+
 # Getting Help / Discussion:
 * For general questions, help, and discussion: use the FireSim user forum: https://groups.google.com/forum/#!forum/firesim
 * For bugs and feature requests: use the github issue tracker: https://github.com/firesim/FireMarshal/issues
-* See CONTRIBUTING.md for more details
+* See CONTRIBUTING.md for information on how to contribute to the project 


### PR DESCRIPTION
The separate 'dev' branch can cause problems/annoyance for little benefit:

1. PRs default to 'master' and people have to explicitly change it to dev each time.
2. Releases are a more complicated process of rc branch->dev, then dev->master.

From now on, we'll PR directly to master which is now the 'unstable' branch. Things should generally work in master (and hopefully we'll get CI setup someday). Stable releases are always tagged and listed in github releases. This matches most github projects that I'm familiar with.