### PR TITLE
More Robust linux-src Unit Test

### DIFF
--- a/test/linux-src/copy-src.sh
+++ b/test/linux-src/copy-src.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-if [ ! -d linux ]; then
-  rsync --exclude ".git" -r ../../boards/default/linux .
-  patch linux/kernel/reboot.c < test.patch
-fi
+rsync --exclude ".git" -r ../../boards/default/linux .
+# rsync --exclude ".git" -r ./deleteme/linux .
+patch linux/kernel/reboot.c < test.patch


### PR DESCRIPTION
The linux-src test could get into a bad state if it was run before initializing FireMarshal's submodules. The error was pretty hard to diagnose. It now unconditionally copies over the linux source from the board instead of trying to check if it's already done it. The build takes a bit longer, but the test won't fail in strange ways.