### PR TITLE
SimArgs Determinism

### DIFF
--- a/test/simArgs.yaml
+++ b/test/simArgs.yaml
@@ -1,7 +1,6 @@
 {
   "name" : "simArgs",
   "base" : "br-base.json",
-  "mem" : "4GiB",
   "cpus" : 2,
   "run" : "reportSimArgs.sh",
   "testing" : {

--- a/test/simArgs/refOutput/simArgs/uartlog
+++ b/test/simArgs/refOutput/simArgs/uartlog
@@ -1,4 +1,2 @@
 Number of CPUs:
 2
-Memory:
-3952

--- a/test/simArgs/reportSimArgs.sh
+++ b/test/simArgs/reportSimArgs.sh
@@ -2,9 +2,5 @@
 echo "Number of CPUs:"
 cat /proc/cpuinfo | grep processor | wc -l
 
-echo "Memory:"
-MEMKB=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
-# Round to the nearest MB to deal with subtle differences in spike vs qemu
-echo $(expr $MEMKB / 1024)
 sync
 poweroff -f


### PR DESCRIPTION
Make the simArgs test only look at CPU. The memory option is unreliable as the exact memory value can vary based on the simulator.

Addresses #125 