### PR TITLE
Newer python support

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -1,5 +1,5 @@
 psutil
-doit
+doit >= 0.34
 gitpython
 humanfriendly
 PyYAML

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -11,7 +11,7 @@ from . import launch as wllaunch
 taskLoader = None
 
 
-class doitLoader(doit.cmd_base.TaskLoader):
+class doitLoader(doit.cmd_base.TaskLoader2):
     workloads = []
 
     # Idempotent add (no duplicates)
@@ -19,9 +19,13 @@ class doitLoader(doit.cmd_base.TaskLoader):
         if not any(t['name'] == tsk['name'] for t in self.workloads):
             self.workloads.append(tsk)
 
-    def load_tasks(self, cmd, opt_values, pos_args):
+    def load_doit_config(self):
+        # return {'run': {**wlutil.getOpt('doitOpts'), **{'check_file_uptodate': wlutil.WithMetadataChecker}}}
+        return {**wlutil.getOpt('doitOpts'), **{'check_file_uptodate': wlutil.WithMetadataChecker}}
+
+    def load_tasks(self, cmd, pos_args):
         task_list = [doit.task.dict_to_task(w) for w in self.workloads]
-        return task_list, {}
+        return task_list
 
 
 def buildBusybox():
@@ -348,8 +352,7 @@ def buildWorkload(cfgName, cfgs, buildBin=True, buildImg=True):
             if 'img' in jCfg and buildImg and not jCfg['img-hardcoded']:
                 imgList.append(jCfg['img'])
 
-    opts = {**wlutil.getOpt('doitOpts'), **{'check_file_uptodate': wlutil.WithMetadataChecker}}
-    doitHandle = doit.doit_cmd.DoitMain(taskLoader, extra_config={'run': opts})
+    doitHandle = doit.doit_cmd.DoitMain(taskLoader)
 
     # The order isn't critical here, we should have defined the dependencies correctly in loader
     return doitHandle.run([str(p) for p in binList + imgList])

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -390,7 +390,7 @@ def inheritFirmwareOpts(config, baseCfg):
             config['firmware']['source'] = config['firmware']['opensbi-src']
 
 
-class Config(collections.MutableMapping):
+class Config(collections.abc.MutableMapping):
     # Configs are assumed to be partially initialized until this is explicitly
     # set.
     initialized = False
@@ -612,7 +612,7 @@ def findConfig(targetName, searchPaths):
 
 
 # The configuration of sw-manager is derived from the *.json files in workloads/
-class ConfigManager(collections.MutableMapping):
+class ConfigManager(collections.abc.MutableMapping):
     # This contains all currently loaded configs, indexed by config file path
     cfgs = {}
 

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -219,7 +219,7 @@ derivedOpts = [
         ]
 
 
-class marshalCtx(collections.MutableMapping):
+class marshalCtx(collections.abc.MutableMapping):
     """Global FireMarshal context (configuration)."""
 
     # Actual internal storage for all options


### PR DESCRIPTION
Fixes some incompatibilities with more recent versions of Python. 3.6 remains the officially supported version, but 3.10 now works as well.

Compatibility break: the doit package will need to be >=0.34 which is the default for 3.6 in pip now, but some users may still be on an older version and will need to update.

Risks: I updated to a newer API for doit and I can't be 100% sure that all the dependency tracking still works exactly the same way. It's very hard to get coverage on dependency tracking, though I do have a few tests and I manually tried a few things.

Addresses: #239 