### PR TITLE
Track busybox-config as a dependency

### DIFF
--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -296,6 +296,7 @@ def buildDepGraph(cfgs):
         'name': 'BuildBusybox',
         'actions': [(buildBusybox, [])],
         'targets': [wlutil.getOpt('initramfs-dir') / 'disk' / 'bin' / 'busybox'],
+        'file_dep': [wlutil.getOpt('wlutil-dir') / 'busybox-config'],
         'uptodate': [wlutil.config_changed(wlutil.checkGitStatus(wlutil.getOpt('busybox-dir'))),
                      wlutil.config_changed(wlutil.getToolVersions())]
         })


### PR DESCRIPTION
The internal busybox-config used for init was not being tracked as a dependency. This meant that changes to busybox-config would not trigger a rebuilt of workloads. Now it's tracked.