### PR TITLE
if no arg is specified, it prints the usage and exits

### DIFF
--- a/marshal
+++ b/marshal
@@ -70,6 +70,11 @@ def main():
 
     args = parser.parse_args()
 
+    # if no arg is specified, it prints the usage and exits.
+    if len(sys.argv) == 1:
+        parser.print_usage()
+        sys.exit(1)
+
     # Perform any basic setup functions for wlutil.
     try:
         wlutil.initialize()


### PR DESCRIPTION
The script failed with the follow error if no arg was specified, which was a bit confusing.  With this PR, the script prints the usage and exists if no arg is specified.

Traceback (most recent call last):
  File ".../chipyard/software/firemarshal/marshal", line 241, in <module>
    main()
  File ".../chipyard/software/firemarshal/marshal", line 91, in main
    for i in range(len(args.config_files)):
AttributeError: 'Namespace' object has no attribute 'config_files'
