### PR TITLE
WIP: Removing excess rebuild

### DIFF
--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -181,8 +181,8 @@ class Builder:
             # # This is unfortunate but buildroot can't remove things from the
             # # image without rebuilding everything from scratch. It adds 20min
             # # to the unit tests and anyone who builds a custom buildroot.
-            wlutil.run(['rm', '-r', 'overlay/*'], cwd=br_dir, env=env)
-            wlutil.run(['rm', '-r', "buildroot/output/target/*"], cwd=br_dir , env=env)
+            wlutil.run(['rm', '-rf', 'overlay/*'], cwd=br_dir, env=env)
+            wlutil.run(['rm', '-rf', "buildroot/output/target/*"], cwd=br_dir , env=env)
             wlutil.run(['make'], cwd=br_dir / "buildroot", env=env)
             shutil.move(img_dir / 'rootfs.ext2', self.outputImg)
 

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -183,8 +183,8 @@ class Builder:
             # # image without rebuilding everything from scratch. It adds 20min
             # # to the unit tests and anyone who builds a custom buildroot.
             wlutil.run(['rm', '-rf', 'overlay/*'], cwd=br_dir, env=env)
-            wlutil.run(['rm', '-rf', "buildroot/output/target/*"], cwd=br_dir , env=env)
-            wlutil.run(['find', 'buildroot/output/', '-name', '".stamp_target_installed"', '-delete'], cwd=br_dir , env=env)
+            wlutil.run(['rm', '-rf', "buildroot/output/target/*"], cwd=br_dir, env=env)
+            wlutil.run(['find', 'buildroot/output/', '-name', '".stamp_target_installed"', '-delete'], cwd=br_dir, env=env)
             wlutil.run(['make'], cwd=br_dir / "buildroot", env=env)
             shutil.move(img_dir / 'rootfs.ext2', self.outputImg)
 

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -176,11 +176,13 @@ class Builder:
             env = {**env, **self.opts['environment']}
 
             self.configure(env)
-
-            # This is unfortunate but buildroot can't remove things from the
-            # image without rebuilding everything from scratch. It adds 20min
-            # to the unit tests and anyone who builds a custom buildroot.
-            wlutil.run(['make', 'clean'], cwd=br_dir / "buildroot", env=env)
+            # The following comments are not true, you do need to specifically
+            # remove things from run dir, but don't need to rebuild everything
+            # # This is unfortunate but buildroot can't remove things from the
+            # # image without rebuilding everything from scratch. It adds 20min
+            # # to the unit tests and anyone who builds a custom buildroot.
+            wlutil.run(['rm', '-r', 'overlay/*'], cwd=br_dir, env=env)
+            wlutil.run(['rm', '-r', "buildroot/output/target/*"], cwd=br_dir , env=env)
             wlutil.run(['make'], cwd=br_dir / "buildroot", env=env)
             shutil.move(img_dir / 'rootfs.ext2', self.outputImg)
 

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -178,11 +178,13 @@ class Builder:
             self.configure(env)
             # The following comments are not true, you do need to specifically
             # remove things from run dir, but don't need to rebuild everything
+            # the find -delete is from https://stackoverflow.com/questions/47320800
             # # This is unfortunate but buildroot can't remove things from the
             # # image without rebuilding everything from scratch. It adds 20min
             # # to the unit tests and anyone who builds a custom buildroot.
             wlutil.run(['rm', '-rf', 'overlay/*'], cwd=br_dir, env=env)
             wlutil.run(['rm', '-rf', "buildroot/output/target/*"], cwd=br_dir , env=env)
+            wlutil.run(['find', 'buildroot/output/', '-name', '".stamp_target_installed"', '-delete'], cwd=br_dir , env=env)
             wlutil.run(['make'], cwd=br_dir / "buildroot", env=env)
             shutil.move(img_dir / 'rootfs.ext2', self.outputImg)
 


### PR DESCRIPTION
Currently buildroot gets rebuilt much too often than necessary. In order to clean off old files from buildroot, it just deleted everything including all the host utils, which can get long at times. Instead, we only need to clean the overlay directory we copy things into and the `output/target/*` directory to generate exact up-to-date image.

The caveat here is that we remove stuff in the overlay folder, which may cause problems if we store persistent files there, but that should be discouraged

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>