### PR TITLE
Misc. Feature Dump

### DIFF
--- a/boards/default/installers/firesim/firesim.py
+++ b/boards/default/installers/firesim/firesim.py
@@ -6,15 +6,17 @@ import wlutil
 
 moduleDir = pathlib.Path(__file__).resolve().parent
 
-readmeTxt="""This workload was generated using FireMarshal. See the following config
+readmeTxt = """This workload was generated using FireMarshal. See the following config
 and workload directory for details:
 """
+
 
 # Create a relative path from base to target. Pathlib.path.relative_to doesn't work.
 # Assumes that wlDir and target are absolute paths (either string or pathlib.Path)
 # Returns a string
 def fullRel(base, target):
     return os.path.relpath(str(target), start=str(base))
+
 
 def install(targetCfg, opts):
     log = logging.getLogger()
@@ -27,7 +29,7 @@ def install(targetCfg, opts):
     if not fsWork.exists():
         raise wlutil.ConfigurationError("Configured firesim-dir (" + str(fsDir) + ") does not appear to be a valid firesim installation")
 
-    if targetCfg['nodisk'] == True:
+    if targetCfg['nodisk']:
         raise NotImplementedError("nodisk builds not currently supported by the install command")
 
     fsTargetDir = fsWork / targetCfg['name']
@@ -40,8 +42,8 @@ def install(targetCfg, opts):
 
     # Firesim config
     fsCfg = {
-            "benchmark_name" : targetCfg['name'],
-            "common_simulation_outputs" : ["uartlog"]
+            "benchmark_name": targetCfg['name'],
+            "common_simulation_outputs": ["uartlog"]
             }
 
     if 'post_run_hook' in targetCfg:
@@ -52,8 +54,8 @@ def install(targetCfg, opts):
         wls = [None]*len(targetCfg['jobs'])
         for slot, jCfg in enumerate(targetCfg['jobs'].values()):
             wls[slot] = {
-                    'name' : jCfg['name'],
-                    'bootbinary' : fullRel(fsTargetDir, jCfg['bin'])
+                    'name': jCfg['name'],
+                    'bootbinary': fullRel(fsTargetDir, jCfg['bin'])
                     }
             if 'img' in jCfg:
                 wls[slot]["rootfs"] = fullRel(fsTargetDir, jCfg['img'])
@@ -61,7 +63,7 @@ def install(targetCfg, opts):
                 wls[slot]["rootfs"] = dummyPath
 
             if 'outputs' in jCfg:
-                wls[slot]["outputs"] = [ f.as_posix() for f in jCfg['outputs'] ]
+                wls[slot]["outputs"] = [f.as_posix() for f in jCfg['outputs']]
         fsCfg['workloads'] = wls
     else:
         # Single-node run
@@ -73,7 +75,7 @@ def install(targetCfg, opts):
             fsCfg["common_rootfs"] = dummyPath
 
         if 'outputs' in targetCfg:
-            fsCfg["common_outputs"] = [ f.as_posix() for f in targetCfg['outputs'] ]
+            fsCfg["common_outputs"] = [f.as_posix() for f in targetCfg['outputs']]
 
     with open(str(fsTargetDir / "README"), 'w') as readme:
         readme.write(readmeTxt)

--- a/boards/default/installers/firesim/firesim.py
+++ b/boards/default/installers/firesim/firesim.py
@@ -2,6 +2,7 @@ import json
 import logging
 import pathlib
 import os
+import wlutil
 
 moduleDir = pathlib.Path(__file__).resolve().parent
 
@@ -20,11 +21,11 @@ def install(targetCfg, opts):
 
     fsDir = opts['firesim-dir']
     if fsDir is None:
-        raise ConfigurationError("No firesim-dir option is set. Please configure the location of firesim in your config.yaml.")
+        raise wlutil.ConfigurationError("No firesim-dir option is set. Please configure the location of firesim in your config.yaml.")
 
     fsWork = opts['firesim-dir'] / "deploy/workloads"
     if not fsWork.exists():
-        raise ConfigurationError("Configured firesim-dir (" + str(fsDir) + ") does not appear to be a valid firesim installation")
+        raise wlutil.ConfigurationError("Configured firesim-dir (" + str(fsDir) + ") does not appear to be a valid firesim installation")
 
     if targetCfg['nodisk'] == True:
         raise NotImplementedError("nodisk builds not currently supported by the install command")

--- a/marshal
+++ b/marshal
@@ -13,11 +13,9 @@ if not shutil.which('riscv64-unknown-linux-gnu-gcc'):
     sys.exit("No riscv toolchain detected. Please install riscv-tools.")
 
 
-# Delete a file but don't throw an exception if it doesn't exist
+# Delete a directory but don't throw an exception if it doesn't exist
 def deleteSafe(pth):
-    with contextlib.suppress(FileNotFoundError):
-        os.remove(pth)
-
+    shutil.rmtree(pth, ignore_errors=True)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -194,14 +192,7 @@ def main():
 
         elif args.command == 'clean':
             def cleanCfg(cfg):
-                if 'bin' in cfg:
-                    deleteSafe(cfg['bin'])
-                    deleteSafe(wlutil.noDiskPath(cfg['bin']))
-                if 'dwarf' in cfg:
-                    deleteSafe(cfg['dwarf'])
-                    deleteSafe(wlutil.noDiskPath(cfg['dwarf']))
-                if 'img' in cfg:
-                    deleteSafe(cfg['img'])
+                deleteSafe(cfg['out-dir'])
 
             cleanCfg(targetCfg)
             if 'jobs' in targetCfg:

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -11,6 +11,7 @@ from . import launch as wllaunch
 
 taskLoader = None
 
+
 # Print task target or file dep changes
 # Taken from: https://github.com/pydoit/doit/issues/329
 def print_deps(task, changed):
@@ -22,6 +23,7 @@ def print_deps(task, changed):
 
     if changed:
         log.debug(f"Running task {task.name} because the following changed: {changed}")
+
 
 class doitLoader(doit.cmd_base.TaskLoader2):
     workloads = []
@@ -39,6 +41,7 @@ class doitLoader(doit.cmd_base.TaskLoader2):
     def load_tasks(self, cmd, pos_args):
         task_list = [doit.task.dict_to_task(w) for w in self.workloads]
         return task_list
+
 
 def buildBusybox(config):
     """Builds the local copy of busybox (needed by linux initramfs).

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -95,6 +95,7 @@ configDeprecated = [
 # This is a comprehensive list of all options set during config parsing
 # (but not explicitly provided by the user)
 configDerived = [
+        'out-dir', # Path to outputs (filesystem images, binaries, extra metadata)
         'img',  # Path to output filesystem image
         'img-sz',  # Desired size of image in bytes (optional)
         'bin',  # Path to output binary (e.g. bbl-vmlinux)
@@ -132,6 +133,7 @@ configInherit = [
         'spike',
         'qemu',
         'launch',
+        'out-dir',
         'bin',
         'img',
         'img-hardcoded',
@@ -472,6 +474,11 @@ class Config(collections.abc.MutableMapping):
         if 'outputs' in self.cfg:
             self.cfg['outputs'] = [pathlib.Path(f) for f in self.cfg['outputs']]
 
+        if 'out-dir' in self.cfg:
+            self.cfg['out-dir'] = wlutil.getOpt('image-dir') / self.cfg['out-dir']
+        else:
+            self.cfg['out-dir'] = wlutil.getOpt('image-dir') / self.cfg['name']
+
         # This object handles setting up the 'run' and 'command' options
         if 'run' in self.cfg:
             self.cfg['runSpec'] = RunSpec.fromString(
@@ -535,7 +542,7 @@ class Config(collections.abc.MutableMapping):
         if 'img' in baseCfg:
             self.cfg['base-img'] = baseCfg['img']
             self.cfg['base-deps'].append(str(self.cfg['base-img']))
-            self.cfg['img'] = wlutil.getOpt('image-dir') / (self.cfg['name'] + ".img")
+            self.cfg['img'] = self.cfg['out-dir'] / (self.cfg['name'] + ".img")
 
         if 'bin' in baseCfg:
             self.cfg['base-bin'] = baseCfg['bin']
@@ -552,8 +559,8 @@ class Config(collections.abc.MutableMapping):
         if 'linux' in self.cfg:
             # Linux workloads get their own binary, whether from scratch or a
             # copy of their parent's
-            self.cfg['bin'] = wlutil.getOpt('image-dir') / (self.cfg['name'] + "-bin")
-            self.cfg['dwarf'] = wlutil.getOpt('image-dir') / (self.cfg['name'] + "-bin-dwarf")
+            self.cfg['bin'] = self.cfg['out-dir'] / (self.cfg['name'] + "-bin")
+            self.cfg['dwarf'] = self.cfg['out-dir'] / (self.cfg['name'] + "-bin-dwarf")
 
             # To avoid needlessly recompiling kernels, we check if the child has
             # the exact same binary-related configuration. If 'use-parent-bin'

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -95,7 +95,7 @@ configDeprecated = [
 # This is a comprehensive list of all options set during config parsing
 # (but not explicitly provided by the user)
 configDerived = [
-        'out-dir', # Path to outputs (filesystem images, binaries, extra metadata)
+        'out-dir',  # Path to outputs (filesystem images, binaries, extra metadata)
         'img',  # Path to output filesystem image
         'img-sz',  # Desired size of image in bytes (optional)
         'bin',  # Path to output binary (e.g. bbl-vmlinux)
@@ -425,10 +425,10 @@ class Config(collections.abc.MutableMapping):
         if 'workdir' in self.cfg:
             self.cfg['workdir'] = pathlib.Path(self.cfg['workdir'])
             if not self.cfg['workdir'].is_absolute():
-                assert('cfg-file' in self.cfg), "'workdir' must be absolute for hard-coded configurations (i.e. those without a config file)"
+                assert ('cfg-file' in self.cfg), "'workdir' must be absolute for hard-coded configurations (i.e. those without a config file)"
                 self.cfg['workdir'] = cfgDir / self.cfg['workdir']
         else:
-            assert('cfg-file' in self.cfg), "No workdir or cfg-file provided"
+            assert ('cfg-file' in self.cfg), "No workdir or cfg-file provided"
             self.cfg['workdir'] = cfgDir / self.cfg['name']
 
         # Convert stuff to absolute paths (this should happen as early as

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -573,7 +573,7 @@ def waitpid(pid):
         time.sleep(0.25)
 
 
-if sp.run(['/usr/bin/sudo', '-ln', 'true'], stdout=sp.DEVNULL).returncode == 0:
+if sp.run(['/usr/bin/sudo', '-ln', 'true'], stderr=sp.DEVNULL, stdout=sp.DEVNULL).returncode == 0:
     # User has passwordless sudo available, use the mount command (much faster)
     sudoCmd = ["/usr/bin/sudo"]
 
@@ -728,7 +728,7 @@ def checkGitStatus(submodule):
     'rebuild' : A random number if the repo should be considered not up to date
         for any reason (e.g. dirty==True or init==False). 0 otherwised.
 
-    This is primarily useful as an input to doit's config_changed() updtodate
+    This is primarily useful as an input to doit's config_changed() uptodate
     helper which considers a workload not uptodate if some string or dictionary
     has changed since the last time it ran. The 'sha' or 'rebuild' fields will
     change if the repo has changed (or we can't tell if it's changed)."""


### PR DESCRIPTION
This PR does a couple of things:
- Creates a folder for each img/bin output (and adds associated metadata files like the Linux config to it)
- Moves some "Applying..." output to the debug logger
- Images are deleted then re-generated when the base image (the image that is copied and modified) is modified
- Add a new `out-dir` config item that specifies the name of the output directory to put the img/bin into (basically `<image-dir>/<out-dir>/{*.img,*.bin}`)
- Fixes an exception not found error when doing FireSim installs and the path is incorrect
- Adds a new action called `print_deps` that prints out the items that forced a rebuild (useful for debugging).

This was tested with (in all cases things worked nicely - things weren't rebuilt unnecessarily):
- Protobuf benchmark suite
- My personal FireMarshal workloads
- fullTest.py (except for the tests that stall in Spike - due to another issue w/ Linux)

