### PR TITLE
Copy simulation_inputs | add docs

### DIFF
--- a/boards/default/installers/firesim/firesim.py
+++ b/boards/default/installers/firesim/firesim.py
@@ -69,7 +69,9 @@ def install(targetCfg, opts):
                 if 'simulation_outputs' in jCfg['firesim']:
                     wls[slot]["simulation_outputs"] = [f.as_posix() for f in jCfg['firesim']['simulation_outputs']]
                 if 'simulation_inputs' in jCfg['firesim']:
-                    wls[slot]["simulation_inputs"] = [f.as_posix() for f in jCfg['firesim']['simulation_inputs']]
+                    wls[slot]["simulation_inputs"] = [os.path.basename(f.as_posix()) for f in jCfg['firesim']['simulation_inputs']]
+                    for f in jCfg['firesim']['simulation_inputs']:
+                      os.system(f"cp {f} {os.path.join(fsTargetDir, os.path.basename(f))}")
 
         fsCfg['workloads'] = wls
     else:
@@ -88,7 +90,9 @@ def install(targetCfg, opts):
             if 'simulation_outputs' in targetCfg['firesim']:
                 fsCfg["common_simulation_outputs"] = [f.as_posix() for f in targetCfg['firesim']['simulation_outputs']]
             if 'simulation_inputs' in targetCfg['firesim']:
-                fsCfg["common_simulation_inputs"] = [f.as_posix() for f in targetCfg['firesim']['simulation_inputs']]
+                fsCfg["common_simulation_inputs"] = [os.path.basename(f.as_posix()) for f in targetCfg['firesim']['simulation_inputs']]
+                for f in targetCfg['firesim']['simulation_inputs']:
+                    os.system(f"cp {f} {os.path.join(fsTargetDir, os.path.basename(f))}")
 
     with open(str(fsTargetDir / "README"), 'w') as readme:
         readme.write(readmeTxt)

--- a/docs/source/workloadConfig.rst
+++ b/docs/source/workloadConfig.rst
@@ -296,6 +296,25 @@ should be absolute with respect to the workload rootfs. Files will be placed
 together in the output directory. You cannot specify the directory structure of
 the output.
 
+simulation_outputs
+^^^^^^^^^^^^^^^^^^^^^
+A list of simulation output files to copy after running firesim. Each path
+should be absolute with respect to the `sim_slot_*` directory.
+
+simulation_inputs
+^^^^^^^^^^^^^^^^^^^^^
+A list of simulation input files to provide to firesim before running simulations.
+Each path should be relative to the firemarshal top directory.
+
+.. Note:: `simulation_outputs` and `simulation_inputs` are specific to firesim 
+   workloads and hence should be wrapped with the `firesim` key.
+   ```
+   firesim: {
+      simulation_inputs: ["./images/br-base/br-base-bin-dwarf"],
+      simulation_outputs: ["memory_stats0.csv", "metasim_stderr.out"]
+   }
+   ```
+
 .. _workload-rootfs-size:
 
 rootfs-size


### PR DESCRIPTION
Address comments on #260.
- Copy `simulation_inputs` into the workload slot directory.
- Add documentation.