### PR TITLE
Faster submodule init with treeless clone

### DIFF
--- a/init-submodules.sh
+++ b/init-submodules.sh
@@ -4,8 +4,9 @@
 # if they need them.
 #
 # You do not need to call this script if you only intend to build bare-metal workloads.
+set -x
 
-git submodule update --init \
+git submodule update --progress --filter=tree:0 --init \
   boards/default/linux \
   boards/default/firmware/opensbi \
   wlutil/busybox \


### PR DESCRIPTION
Core Feature: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
How Github tested this: https://github.blog/2020-12-22-git-clone-a-data-driven-study-on-cloning-behaviors/

Tested with Chipyard/FireSim's git version `2.40.1`. Dramatically speeds up init submodule time on the a* machines *without* affecting downstream git commands.

If we want to be a bit more conservative we can do a "blobless" clone
