### PR TITLE
Cached Buildroot Images

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,7 +110,7 @@ jobs:
           ulimit -Sn $(ulimit -Hn)
 
   build-upload-br-image:
-    name: run-tests
+    name: build-upload-br-image
     needs: [setup-repo]
     if: ${{ github.ref == 'master' }}
     runs-on: local-fpga

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,7 +61,7 @@ jobs:
     name: setup-repo
     needs: change-filters
     if: needs.change-filters.outputs.run-core == 'true'
-    runs-on: local-fpga
+    runs-on: firemarshal
     steps:
       - name: Delete old checkout
         run: |
@@ -113,7 +113,7 @@ jobs:
     name: build-upload-br-image
     needs: [setup-repo]
     if: ${{ github.ref == 'master' }}
-    runs-on: local-fpga
+    runs-on: firemarshal
     steps:
       - name: Build buildroot image
         run: |
@@ -126,7 +126,7 @@ jobs:
   run-tests:
     name: run-tests
     needs: [setup-repo]
-    runs-on: local-fpga
+    runs-on: firemarshal
     steps:
       - name: Run tests (- spike tests)
         run: |
@@ -143,7 +143,7 @@ jobs:
   cleanup:
     name: cleanup
     needs: [setup-repo, build-upload-br-image, run-tests]
-    runs-on: local-fpga
+    runs-on: firemarshal
     if: ${{ always() }}
     steps:
       - name: Delete repo copy and conda env

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,13 +1,22 @@
 name: run-tests
 
 on:
+  # run ci when the following branches are pushed to (i.e. after merge)
+  push:
+    branches:
+      - master
   # run ci when pring to following branches (note: ci runs on the merge commit of the pr!)
   pull_request:
     branches:
       - master
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
 env:
   REMOTE_WORK_DIR: /scratch/buildbot/firemarshal-ci-shared/firemarshal-${{ github.sha }}
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.FIREMARSHAL_BR_UPLOAD_GH_PERSONAL_ACCESS_KEY }}
 
 jobs:
   cancel-prior-workflows:
@@ -52,7 +61,7 @@ jobs:
     name: setup-repo
     needs: change-filters
     if: needs.change-filters.outputs.run-core == 'true'
-    runs-on: self-hosted
+    runs-on: local-fpga
     steps:
       - name: Delete old checkout
         run: |
@@ -61,7 +70,7 @@ jobs:
             rm -rf ${{ env.REMOTE_WORK_DIR }}/.* || true
             rm -rf ${{ github.workspace }}/* || true
             rm -rf ${{ github.workspace }}/.* || true
-      
+
       - uses: actions/checkout@v3
       - name: Setup repo copy
         run: |
@@ -100,10 +109,24 @@ jobs:
           fi
           ulimit -Sn $(ulimit -Hn)
 
+  build-upload-br-image:
+    name: run-tests
+    needs: [setup-repo]
+    if: ${{ github.ref == 'master' }}
+    runs-on: local-fpga
+    steps:
+      - name: Build buildroot image
+        run: |
+          cd ${{ env.REMOTE_WORK_DIR }}
+          eval "$(conda shell.bash hook)"
+          conda activate $PWD/.conda-env
+          ./marshal -v build br-base.json
+          ./scripts/upload-br-image.py
+
   run-tests:
     name: run-tests
     needs: [setup-repo]
-    runs-on: self-hosted
+    runs-on: local-fpga
     steps:
       - name: Run tests (- spike tests)
         run: |
@@ -119,9 +142,9 @@ jobs:
 
   cleanup:
     name: cleanup
-    needs: [setup-repo, run-tests]
-    runs-on: self-hosted
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
+    needs: [setup-repo, build-upload-br-image, run-tests]
+    runs-on: local-fpga
+    if: ${{ always() }}
     steps:
       - name: Delete repo copy and conda env
         run: |

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -53,7 +53,7 @@ jobs:
           ulimit -Sn $(ulimit -Hn)
 
   build-upload-br-image:
-    name: run-tests
+    name: build-upload-br-image
     needs: [setup-repo]
     runs-on: local-fpga
     steps:

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,0 +1,76 @@
+name: weekly-build
+
+on:
+  schedule:
+    - cron: "0 0 12 ? * MON *"
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+env:
+  REMOTE_WORK_DIR: /scratch/buildbot/firemarshal-ci-shared/firemarshal-${{ github.sha }}
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.FIREMARSHAL_BR_UPLOAD_GH_PERSONAL_ACCESS_KEY }}
+
+jobs:
+  setup-repo:
+    name: setup-repo
+    needs: change-filters
+    if: needs.change-filters.outputs.run-core == 'true'
+    runs-on: local-fpga
+    steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ${{ env.REMOTE_WORK_DIR }}/* || true
+            rm -rf ${{ env.REMOTE_WORK_DIR }}/.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
+      - uses: actions/checkout@v3
+      - name: Setup repo copy
+        run: |
+          git clone $GITHUB_WORKSPACE ${{ env.REMOTE_WORK_DIR }}
+      - name: Setup conda (install all deps)
+        run: |
+          cd ${{ env.REMOTE_WORK_DIR }}
+          conda env create -f ./conda-reqs.yaml -p ./.conda-env
+          eval "$(conda shell.bash hook)"
+          conda install -y -p $PWD/.conda-env -c ucb-bar riscv-tools=1.0.4
+      - name: Initialize all submodules
+        run: |
+          cd ${{ env.REMOTE_WORK_DIR }}
+          eval "$(conda shell.bash hook)"
+          conda activate $PWD/.conda-env
+          ./init-submodules.sh
+      - name: Verify open file limits
+        run: |
+          HARD_LIMIT=$(ulimit -Hn)
+          REQUIRED_LIMIT=16384
+          if [ "$HARD_LIMIT" -lt "$REQUIRED_LIMIT" ]; then
+              echo "ERROR: Your system does not support an open files limit (the output of 'ulimit -Sn' and 'ulimit -Hn') of at least $REQUIRED_LIMIT, which is required to workaround a bug in buildroot. You will not be able to build a Linux distro with FireMarshal until this is addressed."
+              exit 1
+          fi
+          ulimit -Sn $(ulimit -Hn)
+
+  build-upload-br-image:
+    name: run-tests
+    needs: [setup-repo]
+    runs-on: local-fpga
+    steps:
+      - name: Build buildroot image
+        run: |
+          cd ${{ env.REMOTE_WORK_DIR }}
+          eval "$(conda shell.bash hook)"
+          conda activate $PWD/.conda-env
+          ./marshal -v build br-base.json
+          ./scripts/upload-br-image.py
+
+  cleanup:
+    name: cleanup
+    needs: [setup-repo, build-upload-br-image]
+    runs-on: local-fpga
+    if: ${{ always() }}
+    steps:
+      - name: Delete repo copy and conda env
+        run: |
+           rm -rf ${{ env.REMOTE_WORK_DIR }}

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -17,7 +17,7 @@ jobs:
     name: setup-repo
     needs: change-filters
     if: needs.change-filters.outputs.run-core == 'true'
-    runs-on: local-fpga
+    runs-on: firemarshal
     steps:
       - name: Delete old checkout
         run: |
@@ -55,7 +55,7 @@ jobs:
   build-upload-br-image:
     name: build-upload-br-image
     needs: [setup-repo]
-    runs-on: local-fpga
+    runs-on: firemarshal
     steps:
       - name: Build buildroot image
         run: |
@@ -68,7 +68,7 @@ jobs:
   cleanup:
     name: cleanup
     needs: [setup-repo, build-upload-br-image]
-    runs-on: local-fpga
+    runs-on: firemarshal
     if: ${{ always() }}
     steps:
       - name: Delete repo copy and conda env

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -2,7 +2,8 @@ name: weekly-build
 
 on:
   schedule:
-    - cron: "0 0 12 ? * MON *"
+    # run at 00:00 on sunday
+    - cron: "0 0 * * 0"
 
 defaults:
   run:

--- a/boards/default/distros/bare/bare.py
+++ b/boards/default/distros/bare/bare.py
@@ -33,7 +33,7 @@ class Builder:
                 'builder': self
                 }
 
-    def buildBaseImage(self):
+    def buildBaseImage(self, task, changed):
         raise NotImplementedError("Baremetal workloads currently do not support disk images")
 
     def upToDate(self):

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -25,11 +25,14 @@ GH_REPO = 'firemarshal-public-br-images'
 GH_ORG = 'firesim'
 URL_PREFIX = f"https://raw.githubusercontent.com/{GH_ORG}/{GH_REPO}"
 
+
 def get_url(file_path):
     return f"{URL_PREFIX}/main/{file_path}"
 
+
 def make_relative(path_str):
     return path_str.replace(str(fm_dir) + "/", "")
+
 
 initTemplate = string.Template("""#!/bin/sh
 

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -6,15 +6,30 @@ import doit
 import hashlib
 import wlutil
 import re
+import zipfile
+import urllib.request
+import time
+import logging
 
 # Note: All argument paths are expected to be absolute paths
 
 # Some common directories for this module (all absolute paths)
 br_dir = pathlib.Path(__file__).parent
+fm_dir = br_dir.parents[3]
 overlay = br_dir / 'overlay'
 
 # Buildroot puts its output images here
 img_dir = br_dir / 'buildroot' / 'output' / 'images'
+
+GH_REPO = 'firemarshal-public-br-images'
+GH_ORG = 'firesim'
+URL_PREFIX = f"https://raw.githubusercontent.com/{GH_ORG}/{GH_REPO}"
+
+def get_url(file_path):
+    return f"{URL_PREFIX}/main/{file_path}"
+
+def make_relative(path_str):
+    return path_str.replace(str(fm_dir) + "/", "")
 
 initTemplate = string.Template("""#!/bin/sh
 
@@ -56,7 +71,9 @@ def hashOpts(opts):
                 h.update(cf.read())
 
     if 'environment' in opts:
-        h.update(str(opts['environment']).encode('utf-8'))
+        # use the relative path for the hash (so it is reproducible across machines)
+        env_str = make_relative(str(opts['environment']))
+        h.update(env_str.encode('utf-8'))
 
     return h.hexdigest()[0:4]
 
@@ -164,11 +181,42 @@ class Builder:
         wlutil.run([mergeScript] + kFrags, cwd=(br_dir / 'buildroot'), env=env)
 
     # Build a base image in the requested format and return an absolute path to that image
-    def buildBaseImage(self):
+    def buildBaseImage(self, task, changed):
         """Ensures that the image file specified by baseConfig() exists and is up to date.
 
         This is called as a doit task.
         """
+        log = logging.getLogger()
+
+        # optimization to get cached br distro image
+        img_rel_path = make_relative(str(self.outputImg))
+        cached_url = get_url(img_rel_path + ".zip")
+        cached_local = f"{br_dir}/{self.outputImg.name}.zip"
+
+        # try N times then move on
+        for i in range(3):
+            try:
+                log.info(f"Attempting to download cached image: {cached_url}")
+                urllib.request.urlretrieve(cached_url, cached_local)
+                break
+            except Exception as e:
+                log.debug(f"urlretrieve exception: {doit.exceptions.TaskFailed(e)}")
+            time.sleep(3)
+
+        if os.path.exists(cached_local):
+            assert len(task.targets) == 1, "Multiple targets detected for buildroot"
+            if not os.path.exists(task.targets[0]) and not changed:
+                log.info(f"Attempting to use cached image: {cached_local}")
+                # check if cached img is sufficient
+                if not wlutil.checkGitStatus(br_dir / 'buildroot')['dirty']:
+                    with zipfile.ZipFile(cached_local, 'r') as zip_ref:
+                        self.outputImg.parent.mkdir(parents=True, exist_ok=True)
+                        zip_ref.extractall(self.outputImg.parent)
+                    os.remove(cached_local)
+                    log.info(f"Skipping full buildroot build. Using cached image: {cached_local}")
+                    return
+            os.remove(cached_local)
+
         try:
             wlutil.checkSubmodule(br_dir / 'buildroot')
 

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -30,7 +30,8 @@ def get_url(file_path):
     return f"{URL_PREFIX}/main/{file_path}"
 
 
-def make_relative(path_str):
+def make_relative(path):
+    path_str = str(path)
     return path_str.replace(str(fm_dir) + "/", "")
 
 
@@ -207,7 +208,7 @@ class Builder:
                 urllib.request.urlretrieve(cached_url, cached_local)
                 break
             except Exception as e:
-                log.debug(f"urlretrieve exception: {doit.exceptions.TaskFailed(e)}")
+                log.debug(f"urlretrieve exception: {e}")
             time.sleep(3)
 
         if os.path.exists(cached_local):

--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -193,6 +193,11 @@ class Builder:
         """Ensures that the image file specified by baseConfig() exists and is up to date.
 
         This is called as a doit task.
+        See more information about the arguments here (or in the source code): https://pydoit.org/tasks.html#keywords-with-task-metadata
+
+        Args:
+            task: a Task object instance (all metadata about the "task" being run) - see doit's task.py source for the variable list
+            changed: list of file depencies that have changed since the last successful execution
         """
         log = logging.getLogger()
 

--- a/boards/default/distros/fedora/fedora.py
+++ b/boards/default/distros/fedora/fedora.py
@@ -52,7 +52,7 @@ class Builder:
                 'img': fed_dir / "rootfs.img"
                 }
 
-    def buildBaseImage(self):
+    def buildBaseImage(self, task, changed):
         wlutil.run(['make', "rootfs.img"], cwd=fed_dir)
 
     def fileDeps(self):

--- a/conda-reqs.yaml
+++ b/conda-reqs.yaml
@@ -9,7 +9,7 @@ platforms:
 
 dependencies:
     - qemu # from ucb-bar channel - https://github.com/ucb-bar/qemu-feedstock
-    - python>=3.8
+    - python>=3.9
     - rsync
     - psutil
     - doit>=0.34
@@ -31,7 +31,7 @@ dependencies:
     - gxx
     - conda-gcc-specs
     - binutils
-    - sysroot_linux-64>=2.17
+    - sysroot_linux-64=2.17
     - patch
     - which
     - sed

--- a/conda-reqs.yaml
+++ b/conda-reqs.yaml
@@ -46,3 +46,4 @@ dependencies:
     - wget
     - findutils
     - lzop
+    - pygithub

--- a/scripts/upload-br-image.py
+++ b/scripts/upload-br-image.py
@@ -68,8 +68,9 @@ def upload_binary_file(local_file_path, gh_file_path):
     return r['commit'].sha
 
 
-def make_relative(path_str):
-    return path_str.replace(str(fm_dir) + "/", "")
+def make_relative(path):
+    path_str = str(path)
+    return path_str.replace(f"{fm_dir}/", "")
 
 
 # only caches firechip board br images
@@ -79,7 +80,6 @@ for e in (fm_dir / 'images' / 'firechip').iterdir():
             if ie.is_file() and ie.suffix == '.img' and "br." in ie.name:
                 ie_zip = str(ie) + ".zip"
                 with zipfile.ZipFile(ie_zip, 'w', zipfile.ZIP_BZIP2, compresslevel=9) as zip_ref:
-                    zip_ref.write(ie)
-                print(ie_zip)
+                    zip_ref.write(ie, ie.name)
                 upload_binary_file(ie_zip, make_relative(ie_zip))
                 os.remove(ie_zip)

--- a/scripts/upload-br-image.py
+++ b/scripts/upload-br-image.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
 from pathlib import Path
 import os
 from github import Github
@@ -13,6 +12,7 @@ fm_dir = script_dir.parent
 GH_REPO = 'firemarshal-public-br-images'
 GH_ORG = 'firesim'
 URL_PREFIX = f"https://raw.githubusercontent.com/{GH_ORG}/{GH_REPO}"
+
 
 # taken from https://stackoverflow.com/questions/63427607/python-upload-files-directly-to-github-using-pygithub
 # IMPORTANT: only works for binary files! (i.e. tar.gz or zip files)
@@ -30,7 +30,7 @@ def upload_binary_file(local_file_path, gh_file_path):
             contents.extend(repo.get_contents(file_content.path))
         else:
             file = file_content
-            all_files.append(str(file).replace('ContentFile(path="','').replace('")',''))
+            all_files.append(str(file).replace('ContentFile(path="', '').replace('")', ''))
 
     with open(local_file_path, 'rb') as file:
         content = file.read()
@@ -67,8 +67,10 @@ def upload_binary_file(local_file_path, gh_file_path):
 
     return r['commit'].sha
 
+
 def make_relative(path_str):
     return path_str.replace(str(fm_dir) + "/", "")
+
 
 # only caches firechip board br images
 for e in (fm_dir / 'images' / 'firechip').iterdir():

--- a/scripts/upload-br-image.py
+++ b/scripts/upload-br-image.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+import os
+from github import Github
+import time
+import zipfile
+
+script_dir = Path(os.path.dirname(os.path.realpath(__file__)))
+fm_dir = script_dir.parent
+
+GH_REPO = 'firemarshal-public-br-images'
+GH_ORG = 'firesim'
+URL_PREFIX = f"https://raw.githubusercontent.com/{GH_ORG}/{GH_REPO}"
+
+# taken from https://stackoverflow.com/questions/63427607/python-upload-files-directly-to-github-using-pygithub
+# IMPORTANT: only works for binary files! (i.e. tar.gz or zip files)
+def upload_binary_file(local_file_path, gh_file_path):
+    print(f":DEBUG: Attempting to upload {local_file_path} to {gh_file_path}")
+
+    g = Github(os.environ['PERSONAL_ACCESS_TOKEN'])
+
+    repo = g.get_repo(f'{GH_ORG}/{GH_REPO}')
+    all_files = []
+    contents = repo.get_contents("")
+    while contents:
+        file_content = contents.pop(0)
+        if file_content.type == "dir":
+            contents.extend(repo.get_contents(file_content.path))
+        else:
+            file = file_content
+            all_files.append(str(file).replace('ContentFile(path="','').replace('")',''))
+
+    with open(local_file_path, 'rb') as file:
+        content = file.read()
+
+    tries = 10
+    delay = 15
+    msg = f"Committing files from {os.environ['GITHUB_SHA']}"
+    upload_branch = 'main'
+    r = None
+
+    # Upload to github
+    git_file = gh_file_path
+    if git_file in all_files:
+        contents = repo.get_contents(git_file)
+        for n in range(tries):
+            try:
+                r = repo.update_file(contents.path, msg, content, contents.sha, branch=upload_branch)
+                break
+            except Exception as e:
+                print(f"Got exception: {e}")
+                time.sleep(delay)
+        assert r is not None, f"Unable to poll 'update_file' API {tries} times"
+        print(f"Updated: {git_file}")
+    else:
+        for n in range(tries):
+            try:
+                r = repo.create_file(git_file, msg, content, branch=upload_branch)
+                break
+            except Exception as e:
+                print(f"Got exception: {e}")
+                time.sleep(delay)
+        assert r is not None, f"Unable to poll 'create_file' API {tries} times"
+        print(f"Created: {git_file}")
+
+    return r['commit'].sha
+
+def make_relative(path_str):
+    return path_str.replace(str(fm_dir) + "/", "")
+
+# only caches firechip board br images
+for e in (fm_dir / 'images' / 'firechip').iterdir():
+    if not e.is_file():
+        for ie in e.iterdir():
+            if ie.is_file() and ie.suffix == '.img' and "br." in ie.name:
+                ie_zip = str(ie) + ".zip"
+                with zipfile.ZipFile(ie_zip, 'w', zipfile.ZIP_BZIP2, compresslevel=9) as zip_ref:
+                    zip_ref.write(ie)
+                print(ie_zip)
+                upload_binary_file(ie_zip, make_relative(ie_zip))
+                os.remove(ie_zip)

--- a/wlutil/build.py
+++ b/wlutil/build.py
@@ -326,7 +326,7 @@ def buildDepGraph(cfgs):
         if config['isDistro'] and 'img' in config:
             loader.addTask({
                     'name': str(config['img']),
-                    'actions': [(config['builder'].buildBaseImage, [])],
+                    'actions': [(config['builder'].buildBaseImage)],
                     'targets': [config['img']],
                     'file_dep': config['builder'].fileDeps(),
                     'uptodate': (config['builder'].upToDate() +

--- a/wlutil/wlutil.py
+++ b/wlutil/wlutil.py
@@ -736,7 +736,7 @@ def checkGitStatus(submodule):
                 'sha': "",
                 'dirty': False,
                 "init": False,
-                "rebuild": ""
+                "rebuild": "",
                 }
 
     try:
@@ -747,13 +747,13 @@ def checkGitStatus(submodule):
                 'sha': "",
                 'dirty': True,
                 "init": False,
-                "rebuild": random.random()
+                "rebuild": random.random(),
                 }
 
     status = {
-            'init': True,
             'sha': repo.head.object.hexsha,
-            'dirty': repo.is_dirty()
+            'dirty': repo.is_dirty(),
+            'init': True,
             }
     if repo.is_dirty():
         # In the absense of a clever way to record changes, we must assume that


### PR DESCRIPTION
This adds support in FireMarshal buildroot to use a cached buildroot image downloaded from the internet. This only happens if all of the following is true:

- The file is successfully fetched from the internet
- No file modifications were made (`changed` var in the code)
- The buildroot image doesn't exist (`task.targets[0]` doesn't exist)
- The buildroot repo isn't dirty (`dirty` dict value in the code)


This also adds 2 CI hooks to build and upload the images:
- A weekly build +upload of the image (so things get updated just in case)
- Whenever `master` is pushed (i.e. after a merge), the CI workflow will re-run and there will be a build + upload of the image

I use https://github.com/firesim/firemarshal-public-br-images as the storage repo.