### PR TITLE
Fix CI + Use bar-tender access

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ defaults:
 
 env:
   REMOTE_WORK_DIR: /scratch/buildbot/firemarshal-ci-shared/firemarshal-${{ github.sha }}
-  PERSONAL_ACCESS_TOKEN: ${{ secrets.FIREMARSHAL_BR_UPLOAD_GH_PERSONAL_ACCESS_KEY }}
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.BARTENDER_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   cancel-prior-workflows:

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -11,12 +11,11 @@ defaults:
 
 env:
   REMOTE_WORK_DIR: /scratch/buildbot/firemarshal-ci-shared/firemarshal-${{ github.sha }}
-  PERSONAL_ACCESS_TOKEN: ${{ secrets.FIREMARSHAL_BR_UPLOAD_GH_PERSONAL_ACCESS_KEY }}
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.BARTENDER_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   setup-repo:
     name: setup-repo
-    if: needs.change-filters.outputs.run-core == 'true'
     runs-on: firemarshal
     steps:
       - name: Delete old checkout

--- a/test/rocc/build.sh
+++ b/test/rocc/build.sh
@@ -9,7 +9,7 @@ mkdir -p $SPIKE_INSTALL
 if [ ! -d riscv-isa-sim ]; then
   git clone https://github.com/riscv/riscv-isa-sim.git
   pushd riscv-isa-sim
-  git checkout 5a50590f25a932cc1f25fe78b9912e9661d37d30
+  git checkout e9848ed3056eba91a5f0d15539358e5a03c66011
   popd
 fi
 

--- a/test/spike/build.sh
+++ b/test/spike/build.sh
@@ -9,7 +9,7 @@ mkdir -p $SPIKE_INSTALL
 if [ ! -d riscv-isa-sim ]; then
   git clone https://github.com/riscv/riscv-isa-sim.git
   pushd riscv-isa-sim
-  git checkout 5a50590f25a932cc1f25fe78b9912e9661d37d30
+  git checkout e9848ed3056eba91a5f0d15539358e5a03c66011
   popd
 
   pushd riscv-isa-sim
@@ -36,4 +36,3 @@ popd
 if [ ! -f hello ]; then
   ln -s ../bare/hello .
 fi
-


### PR DESCRIPTION
- Switches CI to use the SSH key and API token given by the `bar-tender` bot.
- Fixes some baremetal CI tests by bumping Spike version
- Fixes weekly build CI