### PR TITLE
Exit on 'launch' job error(s)

### DIFF
--- a/wlutil/launch.py
+++ b/wlutil/launch.py
@@ -126,7 +126,7 @@ def launchWorkload(baseConfig, jobs=None, spike=False, silent=False):
             if config['launch']:
                 runResDir = baseResDir / config['name']
                 uartLog = runResDir / "uartlog"
-                uartlogs.append(uartlog)
+                uartlogs.append(uartLog)
                 os.makedirs(runResDir)
 
                 if spike:

--- a/wlutil/launch.py
+++ b/wlutil/launch.py
@@ -162,7 +162,7 @@ def launchWorkload(baseConfig, jobs=None, spike=False, silent=False):
             try:
                 with open(uartlog, 'r') as f:
                     last_line = f.readlines()[-1]
-                    if not 'COMMAND_EXIT_CODE="0"' in last_line:
+                    if 'COMMAND_EXIT_CODE="0"' not in last_line:
                         raise RuntimeError("One (or more) job(s) returned a non-zero error code. Please check output.")
             except FileNotFoundError:
                 raise RuntimeError(f"Unable to check output of job with {uartlog} uartlog.")

--- a/wlutil/launch.py
+++ b/wlutil/launch.py
@@ -119,12 +119,14 @@ def launchWorkload(baseConfig, jobs=None, spike=False, silent=False):
     baseResDir = wlutil.getOpt('res-dir') / wlutil.getOpt('run-name')
 
     screenIdentifiers = {}
+    uartlogs = []
 
     try:
         for config in configs:
             if config['launch']:
                 runResDir = baseResDir / config['name']
                 uartLog = runResDir / "uartlog"
+                uartlogs.append(uartlog)
                 os.makedirs(runResDir)
 
                 if spike:
@@ -155,6 +157,15 @@ def launchWorkload(baseConfig, jobs=None, spike=False, silent=False):
 
         for proc in jobProcs:
             proc.wait()
+
+        for uartlog in uartlogs:
+            try:
+                with open(uartlog, 'r') as f:
+                    last_line = f.readlines()[-1]
+                    if not 'COMMAND_EXIT_CODE="0"' in last_line:
+                        raise RuntimeError("One (or more) job(s) returned a non-zero error code. Please check output.")
+            except FileNotFoundError:
+                raise RuntimeError(f"Unable to check output of job with {uartlog} uartlog.")
 
     except Exception:
         cleanUpSubProcesses()


### PR DESCRIPTION
If a "launch"ed job returns a non-zero error code we should exit with a non-zero error code as well (useful for automation).