### PR TITLE
Remove unset LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -131,8 +131,6 @@ jobs:
     steps:
       - name: Run tests (- spike tests)
         run: |
-          env
-          unset LD_LIBRARY_PATH
           cd ${{ env.REMOTE_WORK_DIR }}
           eval "$(conda shell.bash hook)"
           conda activate $PWD/.conda-env


### PR DESCRIPTION
This should now be fixed on the CI machine directly (removing trailing `:`s). Fixes https://github.com/firesim/FireMarshal/pull/307/files#r1679799271